### PR TITLE
💄(footer) fix link hover color

### DIFF
--- a/sites/nau/CHANGELOG.md
+++ b/sites/nau/CHANGELOG.md
@@ -8,6 +8,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+- 💄(footer) fix link hover color
 - ♻️(styles) refactor style to reflect merge maps
 
 ### Changed

--- a/sites/nau/src/frontend/scss/extras/components/_footer.scss
+++ b/sites/nau/src/frontend/scss/extras/components/_footer.scss
@@ -34,7 +34,7 @@
       width: 100%;
       height: 100%;
       fill: r-color("white");
-      transition: fill 0.4s ease;
+      transition: fill 0.2s ease;
     }
 
     &:hover {
@@ -65,7 +65,9 @@
   &__menu {
     a {
       &:hover {
-        text-decoration-color: r-color("greenteal");
+        color: r-color("greenteal");
+        text-decoration: none;
+        transition: color 0.2s ease;
       }
     }
   }


### PR DESCRIPTION
When we reseted the <a> elements, the footer inherited the default color. This fixes the issue and removes the underline.