### PR TITLE
🐛(search) fix header and home search component

### DIFF
--- a/sites/nau/CHANGELOG.md
+++ b/sites/nau/CHANGELOG.md
@@ -15,6 +15,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- 🐛(search) fix header and home search component
 - 🌐(i18n) translate missing string
 
 ### Changed

--- a/sites/nau/src/backend/templates/richie/base.html
+++ b/sites/nau/src/backend/templates/richie/base.html
@@ -23,6 +23,11 @@
     {{ block.super }}
 {% endblock body_header %}
 
+{% block topbar_searchbar %}
+<div class="topbar__search richie-react richie-react--root-search-suggest-field"
+    data-props='{"courseSearchPageUrl": "{% page_url 'courses-search' %}"}'></div>
+{% endblock topbar_searchbar %}
+
 {% block topbar_contact %}
 {% endblock topbar_contact %}
 

--- a/sites/nau/src/backend/templates/richie/large_banner/hero-intro.html
+++ b/sites/nau/src/backend/templates/richie/large_banner/hero-intro.html
@@ -15,7 +15,7 @@
             <div class="hero-intro__search">
 
                 <div class="richie-react richie-react--root-search-suggest-field"
-                    data-props='{"courseSearchPageUrl": "{% page_url 'courses' %}"}'></div>
+                    data-props='{"courseSearchPageUrl": "{% page_url 'courses-search' %}"}'></div>
 
                 <a class="hero-intro__cta" href="{% page_url 'courses' %}">
                     {% trans "Explore our courses" %}


### PR DESCRIPTION
Fix the search component that is included on header and on the homepage.
The search was redirecting to the /en/course/ page.
That is configured has a DjangoCMS redirect page.
The redirect lost the `query` URL parameter.
The solution is to set the `courses-search` on the /en/courses page.
Then the search component generate URLs directly to the correct page.
Fixes GN-754