### PR TITLE
💄(header) order of language/login/register

### DIFF
--- a/sites/nau/CHANGELOG.md
+++ b/sites/nau/CHANGELOG.md
@@ -8,6 +8,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- 💄(header) preserve the order of the components language change combo box, 
+  login and register buttons, so they have the same presentation as the LMS.
+
 ## [1.3.0] - 2022-02-11
 
 ### Added

--- a/sites/nau/src/frontend/scss/extras/components/_header.scss
+++ b/sites/nau/src/frontend/scss/extras/components/_header.scss
@@ -102,4 +102,44 @@
     }
   }
 
+  // Change order of Login and Register.
+  &__item {
+    &--login {
+      .user-login {
+        &__btn {
+          &--log-in {
+            order: 1;
+            color: r-color('firebrick6');
+            background: transparent;
+            border-color: transparent;
+            text-transform: uppercase;
+            &:hover {
+              color: r-color('firebrick6') !important;
+            }
+            .icon {
+              display: none;
+            }
+          }
+          &--sign-up {
+            order: 2;
+            background: #074ce1;
+            color: r-color('white');
+            &:hover {
+              color: r-color('white') !important;
+            }
+          }
+        }
+      }
+    }
+  }
+  // Change order of Language changer and the Login/Register block.
+  &__list {
+    &--controls {
+      order: 3;
+    }
+    .richie-react--language-selector {
+      order: 2;
+    }
+  }
+
 }


### PR DESCRIPTION
On header preserve the order of the components:
- language change combo box,
- login button
- register button
So they have the same presentation as the LMS.

@sandroscosta  please review this change.
https://plataforma-nau.atlassian.net/browse/GN-786
