### PR TITLE
💄(course_detail) higher enroll button

### DIFF
--- a/sites/nau/CHANGELOG.md
+++ b/sites/nau/CHANGELOG.md
@@ -14,6 +14,12 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- 💄(course_detail) higher enroll button.
+  Move enroll button for open to enroll course runs to be higher on the
+  screen. For a single open course run the enroll button is visible on
+  the right using a desktop viewport. If using mobile at 
+  least it will be visible for simple swipe instead of scrolling
+  to the button of the screen.
 - ⬆️(richie) upgrade richie to v2.13.0
 - ⬆️(search) upgrade elastic search to 7.17.0
 

--- a/sites/nau/src/backend/templates/courses/cms/course_detail.html
+++ b/sites/nau/src/backend/templates/courses/cms/course_detail.html
@@ -1,4 +1,34 @@
 {% extends "courses/cms/course_detail.html" %}
+{% load cms_tags i18n %}
 
 {% block contact %}
+{% with runs_dict=course.course_runs_dict %}
+    <div class="course-detail__row course-detail__runs course-detail__runs--open">
+        {% for run in runs_dict.0|add:runs_dict.1|add:runs_dict.2|dictsort:"start"|slice:":1" %}
+            {% include "courses/cms/fragment_course_run.html" %}
+        {% endfor %}
+    </div>
+{% endwith %}
 {% endblock contact %}
+
+{% block runs_open %}
+<div class="course-detail__row course-detail__runs course-detail__runs--open">
+    <h2 class="course-detail__title">
+        {% blocktrans context "course_detail__title" %}Other course runs{% endblocktrans %}
+        {% render_model_add course "" "" "get_admin_url_to_add_run" %}
+    </h2>
+    {% with open_runs=runs_dict.0|add:runs_dict.1|add:runs_dict.2|dictsort:"start" %}
+        {% for run in open_runs %}
+            {% if forloop.counter > 1 %}
+                {% include "courses/cms/fragment_course_run.html" %}
+            {% else %}
+                {% if forloop.last %}
+                    <div class="course-detail__empty">{% trans "No other open course runs" %}</div>
+                {% endif %}
+            {% endif %}
+        {% empty %}
+            <div class="course-detail__empty">{% trans "No open course runs" %}</div>
+        {% endfor %}
+    {% endwith %}
+</div>
+{% endblock runs_open %}

--- a/sites/nau/src/frontend/scss/_extras.scss
+++ b/sites/nau/src/frontend/scss/_extras.scss
@@ -21,4 +21,5 @@
 // Shared object overrides
 @import "./extras/components/templates/richie/large_banner/large_banner";
 @import "./extras/components/templates/courses/cms/blogpost_details";
+@import "./extras/components/templates/courses/cms/course_detail";
 @import "./extras/components/blogpost_glimpses";

--- a/sites/nau/src/frontend/scss/extras/components/templates/courses/cms/course_detail.scss
+++ b/sites/nau/src/frontend/scss/extras/components/templates/courses/cms/course_detail.scss
@@ -1,0 +1,7 @@
+.course-detail {
+  &__row {
+    margin-top: 2rem;
+    text-align: left;
+  }
+}
+  


### PR DESCRIPTION
Move enroll button for open to enroll course runs to be higher on the
screen. For a single open course run the enroll button is visible on
the right using a desktop viewport. If using mobile at
least it will be visible for simple swipe instead of scrolling
to the button of the screen.