### PR TITLE
💄(course_detail) remove excessive text in skills

### DIFF
--- a/sites/nau/CHANGELOG.md
+++ b/sites/nau/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- 💄(course_detail) remove excessive text in "What you'll learn"
 - 🐛(css) fix blog category tags text color
 
 ### Changed

--- a/sites/nau/src/backend/templates/courses/cms/course_detail.html
+++ b/sites/nau/src/backend/templates/courses/cms/course_detail.html
@@ -1,5 +1,5 @@
 {% extends "courses/cms/course_detail.html" %}
-{% load cms_tags i18n %}
+{% load cms_tags i18n extra_tags %}
 
 {% block contact %}
 {% with runs_dict=course.course_runs_dict %}
@@ -32,3 +32,12 @@
     {% endwith %}
 </div>
 {% endblock runs_open %}
+
+{% block skills %}
+    {% if current_page.publisher_is_draft or not current_page|is_empty_placeholder:"course_skills" %}
+    <div class="course-detail__row course-detail__skills">
+        <h2 class="course-detail__title">{% blocktrans context "course_detail__title" %}What you will learn{% endblocktrans %}</h2>
+        {% placeholder "course_skills" %}
+    </div>
+    {% endif %}
+{% endblock skills %}

--- a/sites/nau/src/frontend/scss/extras/components/_subheader.scss
+++ b/sites/nau/src/frontend/scss/extras/components/_subheader.scss
@@ -38,6 +38,15 @@ $r-subheader-search-title-width: 19rem !default; // aligned on computed search r
 
   }
 
+  &__media {
+
+    img {
+      width: initial;
+      max-height: 6.5rem;
+    }
+
+  }
+
   .breadcrumbs {
     background: r-color("light-blue");
   }


### PR DESCRIPTION
Remove the "In this course you'll learn..." so you can place any text on the "What you'll learn" placeholder.
Replace the red checkmark for a blue one.
Tweak the `_subheader`.
