### PR TITLE
💄(course_detail) fix title color and size

### DIFF
--- a/sites/nau/CHANGELOG.md
+++ b/sites/nau/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- 💄(course_detail) fix title size and color of plan and organization
 - 💚(circleci) fix circleci check configuration step
 - 🌐(i18n) fix missing translations
 

--- a/sites/nau/src/frontend/scss/extras/components/templates/courses/cms/_course_detail.scss
+++ b/sites/nau/src/frontend/scss/extras/components/templates/courses/cms/_course_detail.scss
@@ -26,5 +26,14 @@
       }
     }
   }
+
+  &__plan &__title {
+    color: inherit;
+  }
+
+  &__organizations &__title {
+    color: inherit !important;
+    @include font-size($h2-font-size);
+  }
 }
   


### PR DESCRIPTION
This PR fixes the `.course-plan__title` color, to make it inherit from previous titles on the page. Reverts the color to black.
The organizations title font size was smaller than any other titles after it, so it was fixed to the `h2` size.

#GN-850