### PR TITLE
🐛(cache) lower content cache

### DIFF
--- a/sites/nau/CHANGELOG.md
+++ b/sites/nau/CHANGELOG.md
@@ -14,6 +14,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - 💚(circleci) fix circleci check configuration step
 - 🌐(i18n) fix missing translations
 
+### Changed
+
+- 🐛(cache) lower page content cache from 1 day to 30 minutes
+
 ## [1.5.0] - 2022-03-14
 
 ### Fixed

--- a/sites/nau/src/backend/nau/settings.py
+++ b/sites/nau/src/backend/nau/settings.py
@@ -771,7 +771,7 @@ class Production(Base):
     # For more details about CMS_CACHE_DURATION, see :
     # http://docs.django-cms.org/en/latest/reference/configuration.html#cms-cache-durations
     CMS_CACHE_DURATIONS = values.DictValue(
-        {"menus": 3600, "content": 86400, "permissions": 86400}
+        {"menus": 3600, "content": 1800, "permissions": 86400}
     )
 
     # By default, Django CMS sends cached responses with a


### PR DESCRIPTION
Lower page content cache from 1 day to 30 minutes