### PR TITLE
🐛(chatbot) requires all parameter even empty

### DIFF
--- a/sites/nau/src/backend/templates/nau/chatbot.html
+++ b/sites/nau/src/backend/templates/nau/chatbot.html
@@ -10,9 +10,7 @@
             s.src = src;
             s.id = 'botscriptpass';
             s.setAttribute("param_curso", "{{ CHATBOT_PARAM_COURSE }}");
-{% comment "In future the user email could be retrieved from React JS code using the LMS API /api/user/v1/accounts/{username}/." %}
-            //s.setAttribute("param_email", userEmail);
-{% endcomment %}
+            s.setAttribute("param_email", "");
             s.onload = s.onreadystatechange = function () {
                 if (!r && (!this.readyState || this.readyState == 'complete')) {
                     r = true;


### PR DESCRIPTION
The user email chatbot parameter should be sent empty even when
we don't have it.
GN-860