### PR TITLE
Enroll button not clickable on small width screen

### DIFF
--- a/sites/nau/CHANGELOG.md
+++ b/sites/nau/CHANGELOG.md
@@ -8,7 +8,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-### Fixed
+### Fixed 
+- 🐛(scss) enroll button is not clickable on small width screens
 - 🐛(scss) persons category tags have the wrong hover color
 - 🐛(scss) fix issues with background on icon tag
 

--- a/sites/nau/src/frontend/scss/extras/components/_subheader.scss
+++ b/sites/nau/src/frontend/scss/extras/components/_subheader.scss
@@ -72,6 +72,8 @@ $r-subheader-search-title-width: 19rem !default; // aligned on computed search r
       // Insert bottom curves
       &::after {
         background-image: none;
+        content: none;
+        position: inherit;
       }
     }
   }


### PR DESCRIPTION
### Issue
The enroll button was not clickable on small width screen due to an issue with an absolute positioned element on the enrollment details column

### PR Details
Fixed an issue with the styles that generated an issue when activating the enroll button on mobile width screens.
#GN-987