### PR TITLE
👷(docker) add app docker image with static assets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -139,7 +139,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # Copy collected symlinks to static files
-COPY --from=collector ${STATIC_ROOT}/staticfiles.json ${STATIC_ROOT}/
+COPY --from=collector ${STATIC_ROOT} ${STATIC_ROOT}
 
 # Un-privileged user running the application
 USER ${DOCKER_USER}

--- a/sites/nau/CHANGELOG.md
+++ b/sites/nau/CHANGELOG.md
@@ -8,6 +8,17 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- 👷(docker) add app `nauedu/nau` docker image with static assets.
+  The nauedu/nau docker image will start to have static assets,
+  to improve rolling deploy of the static assets.
+  We will stop use the `nauedu/nau-nginx` docker image and use the
+  newer dynamic built nginx image.
+  This newer nginx image will have the static assets from both 
+  current/older and new releases, so the user don't view a missing css
+  during the rolling deploy.
+
 ## [1.16.0] - 2022-10-25
 
 ### Changed


### PR DESCRIPTION
The nauedu/nau docker image will start to have static assets, to improve rolling deploy of the static assets.
We will stop use the `nauedu/nau-nginx` docker image and use the newer dynamic built nginx image.
This newer nginx image will have the static assets from both current/older and new releases, so the user don't view a missing css during the rolling deploy.
GN-998
GN-1002