### PR TITLE
📈(web_analytics) add custom dimensions to GTM

### DIFF
--- a/sites/nau/CHANGELOG.md
+++ b/sites/nau/CHANGELOG.md
@@ -11,6 +11,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 
 - ✨(cookies) make cookie bar optional, to activate it use COOKIE_BAR setting.
+- 📈(web_analytics) add custom dimensions to NAU custom Google Tag Manager.
 
 ### Fixed
 

--- a/sites/nau/src/backend/templates/richie/web_analytics.html
+++ b/sites/nau/src/backend/templates/richie/web_analytics.html
@@ -3,6 +3,15 @@
     {{ block.super }}
     {% if GOOGLE_TAG_MANAGER_ID %}
         <!-- Google Tag Manager -->
+        <script>
+            window.dataLayer = window.dataLayer || [];
+            window.dataLayer.push({
+            'event' : 'pageview',
+            {% for dimension_key, dimension_value_list in WEB_ANALYTICS_DIMENSIONS.items %}
+            '{{ dimension_key }}': '{{ dimension_value_list|join:" | " }}',
+            {% endfor %}
+            });
+        </script>
         <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
         new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
         j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=


### PR DESCRIPTION
Add custom dimensions key/value on custom code for Google Tag Manager. GN-1079