### PR TITLE
💄(footer) increase footer white size

### DIFF
--- a/sites/nau/CHANGELOG.md
+++ b/sites/nau/CHANGELOG.md
@@ -18,6 +18,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - 🐛(gitmoji) fix git lint with emoji
 
+## Changed
+
+- 💄(footer) Increase the size of the white part of footer where
+some logos are put.
+
 ## [1.17.0] - 2022-11-11
 
 ### Added

--- a/sites/nau/src/frontend/scss/extras/components/_footer.scss
+++ b/sites/nau/src/frontend/scss/extras/components/_footer.scss
@@ -75,6 +75,8 @@
 
 // Legal mentions
 .body-mentions {
+  padding-bottom: 5rem;
+
   &__container {
     @include make-container();
     @include make-container-max-widths();


### PR DESCRIPTION
Increase the size of the white part of footer where some logos are put.

Problem:
The cookie message are overlapping the footer logos.
![image](https://user-images.githubusercontent.com/67018/213438938-105ffde2-e6ff-4fb3-88b3-e73fc9843dc2.png)



Changed to:
![image](https://user-images.githubusercontent.com/67018/213444951-1ff260a5-7fba-413c-9a09-6a69cc8e4944.png)
