### PR TITLE
⬆️(nau) upgrade python dev dependencies

### DIFF
--- a/sites/nau/CHANGELOG.md
+++ b/sites/nau/CHANGELOG.md
@@ -17,6 +17,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - ⬆️(nau) upgrade richie to v2.20.1
+- ⬆️(nau) upgrade python dev dependencies
 
 ### Fixed
 

--- a/sites/nau/requirements/dev.txt
+++ b/sites/nau/requirements/dev.txt
@@ -1,15 +1,15 @@
-bandit==1.7.2
+bandit==1.7.4
 black==22.3.0
-Faker==13.2.0
 factory-boy==3.2.1
+Faker==13.2.0
 flake8==4.0.1
 isort==5.10.1
-pylint==2.12.2
-pylint-django==2.5.2
-pytest==7.1.1
+pylint==2.14.3
+pylint-django==2.5.3
+pytest==7.1.2
 pytest-cov==3.0.0
 pytest-django==4.5.2
-raincoat==1.0.1
+raincoat==1.2.4
 
 # Testing html
 lxml==4.9.1


### PR DESCRIPTION
Upgrade python development dependencies:
- bandit
- pylint
- pylint-django
- pytest
- raincoat