### PR TITLE
🐛(search) fix redirect for the search course page

### DIFF
--- a/sites/nau/CHANGELOG.md
+++ b/sites/nau/CHANGELOG.md
@@ -8,6 +8,13 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- 🐛(search) fix redirect for the search course page.
+  After the upgrade of django-cms v3.11.2 we can enable
+  `CMS_REDIRECT_PRESERVE_QUERY_PARAMS` setting that fix the redirect of
+  the parent courses page isn't the same of the course search.
+
 ### Changed
 
 - ⬆️(dependencies) upgrade python dependencies

--- a/sites/nau/src/backend/nau/settings.py
+++ b/sites/nau/src/backend/nau/settings.py
@@ -641,6 +641,10 @@ class Base(StyleguideMixin, DRFMixin, RichieCoursesConfigurationMixin, Configura
 
     CMS_LIMIT_TTL_CACHE_FUNCTION = "nau.cache.cache_ttl.limit_course_page_cache_ttl"
 
+    # Preserve the query parameters during redirection of `/en/course`` to `/en/courses` rendered
+    # on different locations of the site.
+    CMS_REDIRECT_PRESERVE_QUERY_PARAMS = True
+
     MAINTENANCE_HEADER_MSG = values.BooleanValue(
         False, environ_name="MAINTENANCE_HEADER_MSG", environ_prefix=None
     )

--- a/sites/nau/src/backend/nau/tests/test_maintenance.py
+++ b/sites/nau/src/backend/nau/tests/test_maintenance.py
@@ -7,7 +7,7 @@ from cms.test_utils.testcases import CMSTestCase
 from richie.apps.courses.factories import CourseFactory
 
 
-class JiraServiceDeskWidgetBaseTemplateRenderingCMSTestCase(CMSTestCase):
+class MaintenanceBaseTemplateRenderingCMSTestCase(CMSTestCase):
     """
     Test case that verifies if the maintenance message is being displayed and the search on header
     if not visible.

--- a/sites/nau/src/backend/nau/tests/test_redirect_course_page.py
+++ b/sites/nau/src/backend/nau/tests/test_redirect_course_page.py
@@ -1,0 +1,34 @@
+"""
+End-to-end tests for the course detail view
+"""
+from cms.test_utils.testcases import CMSTestCase
+from richie.apps.core.helpers import create_i18n_page
+
+
+class RedirectWidgetBaseTemplateRenderingCMSTestCase(CMSTestCase):
+    """
+    Test case that verifies if the redirect message is being displayed and the search on header
+    if not visible.
+    """
+
+    def test_redirect_course_page(self):
+        """
+        Test if we change the `LANGUAGE_COOKIE_NAME` setting, it will change the response page
+        language.
+        """
+        args = {"redirect": "/en/courses/"}
+        parent_course_page = create_i18n_page(
+            {
+                "en": "Parent course page without course search",
+                "pt": "Página pai de todos os cursos sem pesquisa",
+            },
+            **args
+        )
+        parent_course_page.publish("en")
+        parent_course_page.publish("pt")
+
+        url = parent_course_page.get_absolute_url(language="en")
+        response = self.client.get(url + "?organizations=1")
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, "/en/courses/?organizations=1")


### PR DESCRIPTION
After the upgrade of django-cms v3.11.2 we can enable `CMS_REDIRECT_PRESERVE_QUERY_PARAMS` setting that fix the redirect of the parent courses page isn't the same of the course search.