### PR TITLE
🐛(language) fix language name on course page

### DIFF
--- a/sites/nau/CHANGELOG.md
+++ b/sites/nau/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- 🐛(language) fix language name on course page
+
 ## [1.20.0] - 2023-04-21
 
 ### Fixed

--- a/sites/nau/src/backend/locale/en/LC_MESSAGES/django.po
+++ b/sites/nau/src/backend/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-03-22 15:44+0000\n"
+"POT-Creation-Date: 2023-05-31 16:36+0100\n"
 "PO-Revision-Date: 2021-07-14 16:32+0100\n"
 "Last-Translator: Ivo Branco <ivo.branco@fccn.pt>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -114,16 +114,16 @@ msgstr ""
 msgid "{base_url:s}/u/(username)"
 msgstr ""
 
-#: nau/settings.py:339
+#: nau/settings.py:338
 msgid "Teaser"
 msgstr ""
 
-#: nau/settings.py:428 nau/settings.py:443
-msgid "English"
+#: nau/settings.py:427 nau/settings.py:442
+msgid "English Lang"
 msgstr "English"
 
-#: nau/settings.py:428 nau/settings.py:451
-msgid "Portuguese"
+#: nau/settings.py:427 nau/settings.py:450
+msgid "Portuguese Lang"
 msgstr "Português"
 
 #: templates/courses/cms/course_detail.html:7
@@ -160,15 +160,15 @@ msgstr "/en/legal/cookies/"
 msgid "Need Help"
 msgstr ""
 
-#: templates/richie/base.html:35
+#: templates/richie/base.html:29
 msgid "Go to homepage"
 msgstr ""
 
-#: templates/richie/base.html:36
+#: templates/richie/base.html:30
 msgid "In maintenance"
 msgstr ""
 
-#: templates/richie/base.html:48
+#: templates/richie/base.html:42
 msgid "Help"
 msgstr ""
 

--- a/sites/nau/src/backend/locale/pt/LC_MESSAGES/django.po
+++ b/sites/nau/src/backend/locale/pt/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-03-22 15:44+0000\n"
+"POT-Creation-Date: 2023-05-31 16:36+0100\n"
 "PO-Revision-Date: 2021-07-14 16:32+0100\n"
 "Last-Translator: Ivo Branco <ivo.branco@fccn.pt>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -114,16 +114,16 @@ msgstr "Perfil"
 msgid "{base_url:s}/u/(username)"
 msgstr ""
 
-#: nau/settings.py:339
+#: nau/settings.py:338
 msgid "Teaser"
 msgstr ""
 
-#: nau/settings.py:428 nau/settings.py:443
-msgid "English"
+#: nau/settings.py:427 nau/settings.py:442
+msgid "English Lang"
 msgstr "English"
 
-#: nau/settings.py:428 nau/settings.py:451
-msgid "Portuguese"
+#: nau/settings.py:427 nau/settings.py:450
+msgid "Portuguese Lang"
 msgstr "Português"
 
 #: templates/courses/cms/course_detail.html:7
@@ -160,17 +160,17 @@ msgstr "/pt/legal/cookies/"
 msgid "Need Help"
 msgstr "Preciso de Ajuda"
 
-#: templates/richie/base.html:35
+#: templates/richie/base.html:29
 #, fuzzy
 #| msgid "Back to home"
 msgid "Go to homepage"
 msgstr "Voltar à página principal"
 
-#: templates/richie/base.html:36
+#: templates/richie/base.html:30
 msgid "In maintenance"
 msgstr "Em manutenção"
 
-#: templates/richie/base.html:48
+#: templates/richie/base.html:42
 msgid "Help"
 msgstr "Ajuda"
 

--- a/sites/nau/src/backend/nau/settings.py
+++ b/sites/nau/src/backend/nau/settings.py
@@ -424,7 +424,7 @@ class Base(StyleguideMixin, DRFMixin, RichieCoursesConfigurationMixin, Configura
     # fallback/default languages throughout the app.
     # Use "en" as default as it is the language that is most likely to be spoken by any visitor
     # when their preferred language, whatever it is, is unavailable
-    LANGUAGES = (("en", _("English")), ("pt", _("Portuguese")))
+    LANGUAGES = (("en", _("English Lang")), ("pt", _("Portuguese Lang")))
 
     # - Django CMS
     CMS_LANGUAGES = {
@@ -439,7 +439,7 @@ class Base(StyleguideMixin, DRFMixin, RichieCoursesConfigurationMixin, Configura
                 "public": True,
                 "code": "en",
                 "hide_untranslated": False,
-                "name": _("English"),
+                "name": _("English Lang"),
                 "fallbacks": ["pt"],
                 "redirect_on_fallback": False,
             },
@@ -447,7 +447,7 @@ class Base(StyleguideMixin, DRFMixin, RichieCoursesConfigurationMixin, Configura
                 "public": True,
                 "code": "pt",
                 "hide_untranslated": False,
-                "name": _("Portuguese"),
+                "name": _("Portuguese Lang"),
                 "fallbacks": ["en"],
                 "redirect_on_fallback": False,
             },


### PR DESCRIPTION
When showing a PT language, but viewing the course in EN, it was showing 'Português' instead of 'Portuguese'.
GN-1186