### PR TITLE
⬆️(nau) upgrade richie to v2.24.1

### DIFF
--- a/sites/nau/CHANGELOG.md
+++ b/sites/nau/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- ⬆️(nau) upgrade richie to v2.24.1
 
 ### Added
 

--- a/sites/nau/requirements/base.txt
+++ b/sites/nau/requirements/base.txt
@@ -6,7 +6,7 @@ django-storages==1.13.2
 dockerflow==2022.8.0
 gunicorn==20.1.0
 psycopg2-binary==2.9.6
-richie==2.23.0
+richie==2.24.1
 requests==2.31.0
 sentry-sdk==1.28.1
 mysqlclient==2.1.1

--- a/sites/nau/src/frontend/package.json
+++ b/sites/nau/src/frontend/package.json
@@ -33,7 +33,7 @@
   },
   "homepage": "https://github.com/fccn/nau-richie-site-factory#readme",
   "dependencies": {
-    "richie-education": "2.23.0",
+    "richie-education": "2.24.1",
     "source-map-loader": "4.0.1"
   },
   "devDependencies": {

--- a/sites/nau/src/frontend/yarn.lock
+++ b/sites/nau/src/frontend/yarn.lock
@@ -5704,17 +5704,10 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react-dom@18.2.7":
+"@types/react-dom@18.2.7", "@types/react-dom@^18.0.0":
   version "18.2.7"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.2.7.tgz#67222a08c0a6ae0a0da33c3532348277c70abb63"
   integrity sha512-GRaAEriuT4zp9N4p1i8BDBYmEyfo+xQ3yHjJU4eiK5NDa1RmUZG+unZABUTK4/Ox/M+GaHwb6Ow8rUITrtjszA==
-  dependencies:
-    "@types/react" "*"
-
-"@types/react-dom@^18.0.0":
-  version "18.0.11"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.0.11.tgz#321351c1459bc9ca3d216aefc8a167beec334e33"
-  integrity sha512-O38bPbI2CWtgw/OoQoY+BRelw7uysmXbWvw3nLWO21H1HSh+GOlqPuXshJfjmpNlKiiSDG9cc1JZAaMmVdcTlw==
   dependencies:
     "@types/react" "*"
 
@@ -5725,19 +5718,10 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*":
-  version "17.0.34"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.34.tgz#797b66d359b692e3f19991b6b07e4b0c706c0102"
-  integrity sha512-46FEGrMjc2+8XhHXILr+3+/sTe3OfzSPU9YGKILLrUYbQ1CLQC9Daqo1KzENGXAWwrFwiY0l4ZbF20gRvgpWTg==
-  dependencies:
-    "@types/prop-types" "*"
-    "@types/scheduler" "*"
-    csstype "^3.0.2"
-
-"@types/react@16 || 17 || 18":
-  version "18.0.14"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.0.14.tgz#e016616ffff51dba01b04945610fe3671fdbe06d"
-  integrity sha512-x4gGuASSiWmo0xjDLpm5mPb52syZHJx02VKbqUKdLmKtAwIh63XClGsiTI1K6DO5q7ox4xAsQrU+Gl3+gGXF9Q==
+"@types/react@*", "@types/react@16 || 17 || 18", "@types/react@>=16":
+  version "18.2.18"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.2.18.tgz#c8b233919eef1bdc294f6f34b37f9727ad677516"
+  integrity sha512-da4NTSeBv/P34xoZPhtcLkmZuJ+oYaCxHmyHzwaDQo9RQPBeXV+06gEk2FpqEcsX9XrnNLvRpVh6bdavDSjtiQ==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"
@@ -5747,15 +5731,6 @@
   version "18.2.15"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-18.2.15.tgz#14792b35df676c20ec3cf595b262f8c615a73066"
   integrity sha512-oEjE7TQt1fFTFSbf8kkNuc798ahTUzn3Le67/PWjE8MAfYAD/qB7O8hSTcromLFqHCt9bcdOg5GXMokzTjJ5SA==
-  dependencies:
-    "@types/prop-types" "*"
-    "@types/scheduler" "*"
-    csstype "^3.0.2"
-
-"@types/react@>=16":
-  version "18.0.37"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.0.37.tgz#7a784e2a8b8f83abb04dc6b9ed9c9b4c0aee9be7"
-  integrity sha512-4yaZZtkRN3ZIQD3KSEwkfcik8s0SWV+82dlJot1AbGYHCzJkWP3ENBY6wYeDRmKZ6HkrgoGAmR2HqdwYGp6OEw==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"
@@ -12865,10 +12840,10 @@ reusify@^1.0.4:
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
   integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
 
-richie-education@2.23.0:
-  version "2.23.0"
-  resolved "https://registry.yarnpkg.com/richie-education/-/richie-education-2.23.0.tgz#1e4b680883e911977171f883087f79a5e850b911"
-  integrity sha512-oyXHkuvatYFzrL15pGUhWdGVooeAioDUwumanfbNn26oiPE5Lw5UKkUKV+BXSE4uv7Tfg18ggbQOsmqbQzUnSg==
+richie-education@2.24.1:
+  version "2.24.1"
+  resolved "https://registry.yarnpkg.com/richie-education/-/richie-education-2.24.1.tgz#4f51218be1be000acc48e9b032a9398d159b7048"
+  integrity sha512-vDlNBcYct8GGPY+JUku7NzkR29kOimeJgY1N3czqVOeZ7MtTHqcJkcweLEy3MoFaaJvcVfa65szuX8y9DdJxcQ==
   dependencies:
     "@babel/core" "7.22.9"
     "@babel/plugin-syntax-dynamic-import" "7.8.3"


### PR DESCRIPTION
Had to upgrade to 2.24.1 to fix the issue with the grid on the Partner Course list now rendering correctly because it was missing a `<div>` container with a `__content` class.