### PR TITLE
📌(backend) pin django-cms to version less than 4

### DIFF
--- a/sites/nau/CHANGELOG.md
+++ b/sites/nau/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- 📌(backend) pin django-cms to version less than 4
+
 ## [1.21.0] - 2023-12-06
 
 ### Added

--- a/sites/nau/requirements/base.txt
+++ b/sites/nau/requirements/base.txt
@@ -10,3 +10,5 @@ richie==2.24.1
 requests==2.31.0
 sentry-sdk==1.28.1
 mysqlclient==2.1.1
+# Remove django-cms dep when upgrading to richie 2.25.0
+django-cms>=3.11.0,<4.0.0


### PR DESCRIPTION
A new major version of Django CMS has been released. It introduces heavy breaking changes so, we pin it to version 3 for now. Richie < 2.25 does not pin this dep so until we upgrade to Richie 2.25 we have to pin this dep on rsf side.

Copied from: https://github.com/openfun/fun-richie-site-factory/commit/ec414b3a6a6ab5d28ee2a186bfc090f9f48d9902