### PR TITLE
⬆️(global) bump docker node image to the latest minor version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ jobs:
         working_directory: ~/fun/sites/<< parameters.site >>
     build-front-production:
         docker:
-            - image: cimg/node:16.15
+            - image: cimg/node:18.19
         parameters:
             site:
                 type: string
@@ -70,7 +70,7 @@ jobs:
         working_directory: ~/fun/sites/<< parameters.site >>/src/frontend/
     check-changelog:
         docker:
-            - image: cimg/base:2022.06
+            - image: cimg/base:2024.01
         parameters:
             site:
                 type: string
@@ -98,7 +98,7 @@ jobs:
         docker:
             - environment:
                 RICHIE_SITE: << parameters.site >>
-              image: cimg/base:2022.06
+              image: cimg/base:2024.01
         parameters:
             image_name:
                 type: string
@@ -108,8 +108,7 @@ jobs:
             - checkout
             - generate-version-file:
                 site: << parameters.site >>
-            - setup_remote_docker:
-                version: 19.03.13
+            - setup_remote_docker
             - run:
                 command: make env.d/aws && make build
                 name: Build docker images
@@ -242,7 +241,7 @@ jobs:
         working_directory: ~/fun
     lint-front:
         docker:
-            - image: cimg/node:16.15
+            - image: cimg/node:18.19
         parameters:
             site:
                 type: string
@@ -281,7 +280,7 @@ jobs:
         working_directory: ~/fun
     no-change:
         docker:
-            - image: cimg/base:2022.06
+            - image: cimg/base:2024.01
         steps:
             - run: echo "Everything is up-to-date ✅"
         working_directory: ~/fun

--- a/.circleci/src/jobs/@docker.yml
+++ b/.circleci/src/jobs/@docker.yml
@@ -7,7 +7,7 @@ hub:
     image_name:
       type: string
   docker:
-    - image: cimg/base:2022.06
+    - image: cimg/base:2024.01
       environment:
         RICHIE_SITE: << parameters.site >>
   working_directory: ~/fun
@@ -17,8 +17,7 @@ hub:
     - generate-version-file:
         site: << parameters.site >>
     # Activate docker-in-docker (with layers caching enabled)
-    - setup_remote_docker:
-        version: 19.03.13
+    - setup_remote_docker
     - run:
         name: Build docker images
         command: make env.d/aws && make build

--- a/.circleci/src/jobs/@frontend.yml
+++ b/.circleci/src/jobs/@frontend.yml
@@ -5,7 +5,7 @@ build-front-production:
     site:
       type: string
   docker:
-    - image: cimg/node:16.15
+    - image: cimg/node:18.19
   working_directory: ~/fun/sites/<< parameters.site >>/src/frontend/
   steps:
     - checkout:
@@ -33,7 +33,7 @@ lint-front:
     site:
       type: string
   docker:
-    - image: cimg/node:16.15
+    - image: cimg/node:18.19
   working_directory: ~/fun/sites/<< parameters.site >>/src/frontend/
   steps:
     - checkout:

--- a/.circleci/src/jobs/@project.yml
+++ b/.circleci/src/jobs/@project.yml
@@ -61,7 +61,7 @@ check-changelog:
     site:
       type: string
   docker:
-    - image: cimg/base:2022.06
+    - image: cimg/base:2024.01
   working_directory: ~/fun
   steps:
     - checkout
@@ -89,7 +89,7 @@ lint-changelog:
 # Check that the CHANGELOG max line length does not exceed 80 characters
 no-change:
   docker:
-    - image: cimg/base:2022.06
+    - image: cimg/base:2024.01
   working_directory: ~/fun
   steps:
     - run: echo "Everything is up-to-date ✅"

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ARG DOCKER_USER=10000
 FROM python:3.10-buster as base
 
 # ---- front-end builder image ----
-FROM node:16.15 as front-builder
+FROM node:18.19 as front-builder
 
 ARG SITE
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -100,7 +100,7 @@ services:
     image: jwilder/dockerize
 
   node:
-    image: node:16.15
+    image: node:18.19
     working_dir: /app/src/frontend
     user: "${DOCKER_USER:-1000}"
     volumes:

--- a/sites/nau/CHANGELOG.md
+++ b/sites/nau/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- ⬆️(global) upgrade node to v18.19
+
 ### Fixed
 
 - 📌(backend) pin django-cms to version less than 4

--- a/sites/nau/src/backend/templates/richie/base.html
+++ b/sites/nau/src/backend/templates/richie/base.html
@@ -14,6 +14,7 @@
 <!-- bullshit -->
 {% endblock meta_favicons %}
 
+<!-- test -->
 {% block branding_topbar %}
     <img src="{% static "richie/images/logo_nau_by_fccn.svg" %}" class="topbar__logo" alt="{{ SITE.name }}">
 {% endblock branding_topbar %}


### PR DESCRIPTION
Bump docker node image to version 18.19

Next Richie release has been released to be executed with node 18.19.
So this PR upgrades the Node version of this repository.

Nevertheless, we should only merge this PR just before we are going to upgrade Richie to the next release.