### PR TITLE
💄(template) override blogpost-badges

### DIFF
--- a/sites/nau/CHANGELOG.md
+++ b/sites/nau/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- 🌐(i18n) override translations to remove "Richie news" from blogpost badges
+
 ## [1.25.0] - 2024-05-13
 
 ### Changed

--- a/sites/nau/src/backend/locale/en/LC_MESSAGES/django.po
+++ b/sites/nau/src/backend/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-24 13:26+0100\n"
+"POT-Creation-Date: 2024-05-14 16:11+0100\n"
 "PO-Revision-Date: 2021-07-14 16:32+0100\n"
 "Last-Translator: Ivo Branco <ivo.branco@fccn.pt>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -89,6 +89,16 @@ msgstr "Follow a course online with NAU"
 #, python-format
 msgid "I just enrolled to the course \"%(title)s\" on Richie: %(url)s"
 msgstr "I just enrolled to the course \"%(title)s\" on NAU: %(url)s"
+
+#: nau/force_translations.py:28
+#, python-format
+msgid "Richie news: %(title)s"
+msgstr "%(title)s"
+
+#: nau/force_translations.py:29
+#, python-format
+msgid "Richie news: %(title)s %(url)s"
+msgstr "%(title)s %(url)s"
 
 #: nau/settings.py:233
 msgid "Dashboard"

--- a/sites/nau/src/backend/locale/pt/LC_MESSAGES/django.po
+++ b/sites/nau/src/backend/locale/pt/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-24 13:26+0100\n"
+"POT-Creation-Date: 2024-05-14 16:11+0100\n"
 "PO-Revision-Date: 2023-09-29 15:46+0100\n"
 "Last-Translator: Ivo Branco <ivo.branco@fccn.pt>\n"
 "Language-Team: \n"
@@ -89,6 +89,16 @@ msgstr "Siga um curso online com a NAU"
 #, python-format
 msgid "I just enrolled to the course \"%(title)s\" on Richie: %(url)s"
 msgstr "Eu acabei de me inscrever no curso \"%(title)s\" na NAU: %(url)s"
+
+#: nau/force_translations.py:28
+#, python-format
+msgid "Richie news: %(title)s"
+msgstr "%(title)s"
+
+#: nau/force_translations.py:29
+#, python-format
+msgid "Richie news: %(title)s %(url)s"
+msgstr "%(title)s %(url)s"
 
 #: nau/settings.py:233
 msgid "Dashboard"

--- a/sites/nau/src/backend/nau/force_translations.py
+++ b/sites/nau/src/backend/nau/force_translations.py
@@ -23,3 +23,7 @@ _("Life-changing learning!")
 # Richie apps/core/templates/social-networks/course-badges.html
 _("Follow a course online with Richie")
 _('I just enrolled to the course "%(title)s" on Richie: %(url)s')
+
+# Richie apps/core/templates/social-networks/blogpost-badges.html
+_("Richie news: %(title)s")
+_("Richie news: %(title)s %(url)s")


### PR DESCRIPTION
Override the `blogpost-badges.html` template to remove the unwanted `Richie news`, when sharing via Twitter

Ultimately we can remove the variables but I decided to keep them in, as it makes the code cleaner.