### PR TITLE
🐛(test) fix run local tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,9 +138,8 @@ lint-front: \
 	lint-front-eslint
 .PHONY: lint-front
 
-test-back: ## run back-end tests, or specific test like `make test-back nau/tests/test_open_graph.py`
-	@args="$(filter-out $@,$(MAKECMDGOALS))" && \
-    DB_PORT=$(DB_PORT) bin/pytest $${args:-${1}}
+test-back: ## run back-end tests: `make test-back ARGS="--reuse-db"` or a specific test `make test-back ARGS="--reuse-db nau/tests/test_open_graph.py"`
+	DB_PORT=$(DB_PORT) bin/pytest $(ARGS)
 .PHONY: test-back
 
 test-front: ## run front-end tests

--- a/env.d/development
+++ b/env.d/development
@@ -11,14 +11,14 @@ RICHIE_ES_HOST=elasticsearch
 # MySQL db container configuration
 MYSQL_ROOT_PASSWORD=pass
 MYSQL_DATABASE=richie_nau
-MYSQL_USER=nau
+MYSQL_USER=richie_nau
 MYSQL_PASSWORD=pass
 
 # App database configuration
 DB_ENGINE=django.db.backends.mysql
 DB_HOST=db
 DB_NAME=richie_nau
-DB_USER=nau
+DB_USER=root
 DB_PASSWORD=pass
 DB_PORT=3306
 DB_OPTION_CHARSET=utf8mb4


### PR DESCRIPTION
After the Richie upgrade, with its Django upgrade, etc.
it was no longer possible to run the local backend tests with the
Makefile target `make test-back`.
This fixes it, making the project and its tests to use the `root` MySQL
database user, instead of using the an application user. So when the
tests are starting up, it can create the new test database on the fly.

fixes fccn/nau-richie-site-factory#250