### PR TITLE
💚(CircleCI): fix check-configuration job

### DIFF
--- a/.circleci/src/jobs/@docker.yml
+++ b/.circleci/src/jobs/@docker.yml
@@ -7,7 +7,7 @@ hub:
     image_name:
       type: string
   docker:
-    - image: cimg/base:2022.06
+    - image: cimg/base:current
       environment:
         RICHIE_SITE: << parameters.site >>
   working_directory: ~/fun
@@ -17,8 +17,7 @@ hub:
     - generate-version-file:
         site: << parameters.site >>
     # Activate docker-in-docker (with layers caching enabled)
-    - setup_remote_docker:
-        version: 19.03.13
+    - setup_remote_docker
     - run:
         name: Build docker images
         command: make env.d/aws && make build

--- a/.circleci/src/jobs/@frontend.yml
+++ b/.circleci/src/jobs/@frontend.yml
@@ -12,8 +12,8 @@ build-front-production:
         path: ~/fun
     - restore_cache:
         keys:
-          - v1-front-dependencies-<< parameters.site >>-{{ checksum "yarn.lock" }}
-          - v1-front-dependencies-<< parameters.site >>-
+          - v2-front-dependencies-<< parameters.site >>-{{ checksum "yarn.lock" }}
+          - v2-front-dependencies-<< parameters.site >>-
     - run:
         name: Install frontend dependencies (with locked dependencies)
         command: yarn install --frozen-lockfile
@@ -26,7 +26,7 @@ build-front-production:
     - save_cache:
         paths:
           - ./node_modules
-        key: v1-front-dependencies-<< parameters.site >>-{{ checksum "yarn.lock" }}
+        key: v2-front-dependencies-<< parameters.site >>-{{ checksum "yarn.lock" }}
 
 lint-front:
   parameters:
@@ -40,8 +40,8 @@ lint-front:
         path: ~/fun
     - restore_cache:
         keys:
-          - v1-front-dependencies-<< parameters.site >>-{{ checksum "yarn.lock" }}
-          - v1-front-dependencies-<< parameters.site >>-
+          - v2-front-dependencies-<< parameters.site >>-{{ checksum "yarn.lock" }}
+          - v2-front-dependencies-<< parameters.site >>-
     - run:
         name: Lint frontend code with prettier & eslint
         command: yarn lint

--- a/.circleci/src/jobs/@project.yml
+++ b/.circleci/src/jobs/@project.yml
@@ -35,7 +35,7 @@ check-configuration:
   # Use machine because the check_configuration script runs some docker images with
   # volume mounts which is not possible with dind
   machine:
-    image: ubuntu-2004:202107-02
+    image: default
   working_directory: ~/fun
   steps:
     - checkout
@@ -61,7 +61,7 @@ check-changelog:
     site:
       type: string
   docker:
-    - image: cimg/base:2022.06
+    - image: cimg/base:current
   working_directory: ~/fun
   steps:
     - checkout
@@ -89,7 +89,7 @@ lint-changelog:
 # Check that the CHANGELOG max line length does not exceed 80 characters
 no-change:
   docker:
-    - image: cimg/base:2022.06
+    - image: cimg/base:current
   working_directory: ~/fun
   steps:
     - run: echo "Everything is up-to-date ✅"


### PR DESCRIPTION
Fix the `check-configuration` job, that checks if the existing configuration of Circle CI is the correct one from the templates.

fix #251