### PR TITLE
⚡️(assets) static assets only on nginx image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,15 +55,6 @@ RUN apt-get update && \
     gettext && \
     rm -rf /var/lib/apt/lists/*
 
-# Install awscli to send static assets to S3 Bucket
-RUN cd / && \
-    apt update && \
-    apt install unzip && \
-    rm -rf /var/lib/apt/lists/* && \
-    curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
-    unzip awscliv2.zip && \
-    ./aws/install && \
-    rm -r aws awscliv2.zip
 
 # Copy installed python dependencies
 COPY --from=back-builder /install /usr/local
@@ -145,7 +136,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # Copy collected symlinks to static files
-COPY --from=collector ${STATIC_ROOT} ${STATIC_ROOT}
+COPY --from=collector ${STATIC_ROOT}/staticfiles.json ${STATIC_ROOT}/
 
 # Un-privileged user running the application
 USER ${DOCKER_USER}
@@ -161,3 +152,13 @@ ARG STATIC_ROOT
 RUN mkdir -p ${STATIC_ROOT}
 
 COPY --from=collector ${STATIC_ROOT} ${STATIC_ROOT}
+
+# Install awscli to send static assets to S3 Bucket
+RUN cd / && \
+    apt update && \
+    apt install unzip && \
+    rm -rf /var/lib/apt/lists/* && \
+    curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
+    unzip awscliv2.zip && \
+    ./aws/install && \
+    rm -r aws awscliv2.zip

--- a/sites/nau/CHANGELOG.md
+++ b/sites/nau/CHANGELOG.md
@@ -12,6 +12,14 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - 🐛(storage) fix missing staticfiles.json after collectstatic
 
+### Changed
+
+- ⚡️(assets) static assets only on nginx image.
+  Remove option of deliver static assets from application
+  docker image, to be more compatible with Richie upstream.
+  Consequence is lower the app docker image size.
+  The awscli was moved to nginx.
+
 ## [1.27.0] - 2024-06-19
 
 ### Changed

--- a/sites/nau/src/backend/nau/urls.py
+++ b/sites/nau/src/backend/nau/urls.py
@@ -87,12 +87,6 @@ if settings.DEBUG:
         + urlpatterns
     )
 
-# Enable the deliver of the static asset files like css, images, fonts, etc.
-# nginx will also deliver this files, but during rolling deploy, the nginx could have one
-# version of the files and the app still running a different version.
-if getattr(settings, "STATIC_FILES_URL_ENABLE", False) and not settings.DEBUG:
-    urlpatterns = staticfiles_urlpatterns() + urlpatterns
-
 handler400 = "richie.apps.core.views.error.error_400_view_handler"  # pylint: disable=invalid-name
 handler403 = "richie.apps.core.views.error.error_403_view_handler"  # pylint: disable=invalid-name
 handler404 = "richie.apps.core.views.error.error_404_view_handler"  # pylint: disable=invalid-name


### PR DESCRIPTION
Remove option of deliver static assets from application docker image, to be more compatible with Richie upstream. Consequence is lower the app docker image size.
The awscli was moved to nginx.