### PR TITLE
🔖(nau) bump to version 1.28.0

### DIFF
--- a/sites/nau/CHANGELOG.md
+++ b/sites/nau/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.28.0] - 2024-06-21
+
 ### Fixed
 
 - 🐛(storage) fix missing staticfiles.json after collectstatic

--- a/sites/nau/src/backend/nau/__init__.py
+++ b/sites/nau/src/backend/nau/__init__.py
@@ -1,2 +1,2 @@
 # pylint: disable=missing-module-docstring
-__version__ = "1.27.0"
+__version__ = "1.28.0"

--- a/sites/nau/src/frontend/package.json
+++ b/sites/nau/src/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nau",
-  "version": "1.27.0",
+  "version": "1.28.0",
   "description": "Richie NAU site on https://www.nau.edu.pt",
   "scripts": {
     "build-sass": "sass scss/_main.scss ../backend/base/static/richie/css/main.css --load-path=node_modules",


### PR DESCRIPTION
Fixed

- 🐛(storage) fix missing staticfiles.json after collectstatic

Changed

- ⚡️(assets) static assets only on nginx image. Remove option of deliver static assets from application docker image, to be more compatible with Richie upstream. Consequence is lower the app docker image size. The awscli was moved to nginx.