### PR TITLE
💄(menu) adjusted and changed translation of the menu links

### DIFF
--- a/sites/nau/CHANGELOG.md
+++ b/sites/nau/CHANGELOG.md
@@ -21,6 +21,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - ⬆️(nau) upgrade richie to v2.32.0
 - ⚰️(setttings) remove unused setting
+- 💄(menu) on Portuguese language changed from Meus cursos to Painel de Cursos
+- 💄(menu) changed menu items positions in accordance with lms
 
 ## [1.28.0] - 2024-06-21
 

--- a/sites/nau/src/backend/locale/en/LC_MESSAGES/django.po
+++ b/sites/nau/src/backend/locale/en/LC_MESSAGES/django.po
@@ -61,19 +61,27 @@ msgid "{base_url:s}/dashboard"
 msgstr ""
 
 #: nau/settings.py:249
-msgid "Account"
-msgstr ""
-
-#: nau/settings.py:250
-msgid "{base_url:s}/account/settings"
-msgstr ""
-
-#: nau/settings.py:253
 msgid "Profile"
 msgstr ""
 
-#: nau/settings.py:254
+#: nau/settings.py:250
 msgid "{base_url:s}/u/(username)"
+msgstr ""
+
+#: nau/settings.py:253
+msgid "Account"
+msgstr ""
+
+#: nau/settings.py:254
+msgid "{base_url:s}/account/settings"
+msgstr ""
+
+#: nau/settings.py:257
+msgid "Order History"
+msgstr ""
+
+#: nau/settings.py:258
+msgid "{base_url:s}/orders/orders"
 msgstr ""
 
 #: nau/settings.py:347

--- a/sites/nau/src/backend/locale/pt/LC_MESSAGES/django.po
+++ b/sites/nau/src/backend/locale/pt/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-12-13 11:43+0000\n"
+"POT-Creation-Date: 2025-01-16 14:00+0000\n"
 "PO-Revision-Date: 2023-09-29 15:46+0100\n"
 "Last-Translator: Ivo Branco <ivo.branco@fccn.pt>\n"
 "Language-Team: \n"
@@ -54,26 +54,34 @@ msgstr "%(title)s %(url)s"
 
 #: nau/settings.py:245
 msgid "Dashboard"
-msgstr "Meus cursos"
+msgstr "Painel de Cursos"
 
 #: nau/settings.py:246
 msgid "{base_url:s}/dashboard"
 msgstr ""
 
 #: nau/settings.py:249
-msgid "Account"
-msgstr "Conta"
-
-#: nau/settings.py:250
-msgid "{base_url:s}/account/settings"
-msgstr ""
-
-#: nau/settings.py:253
 msgid "Profile"
 msgstr "Perfil"
 
-#: nau/settings.py:254
+#: nau/settings.py:250
 msgid "{base_url:s}/u/(username)"
+msgstr ""
+
+#: nau/settings.py:253
+msgid "Account"
+msgstr "Conta"
+
+#: nau/settings.py:254
+msgid "{base_url:s}/account/settings"
+msgstr ""
+
+#: nau/settings.py:257
+msgid "Order History"
+msgstr "Histórico de compras"
+
+#: nau/settings.py:258
+msgid "{base_url:s}/orders/orders"
 msgstr ""
 
 #: nau/settings.py:347

--- a/sites/nau/src/backend/nau/settings.py
+++ b/sites/nau/src/backend/nau/settings.py
@@ -245,13 +245,17 @@ class Base(StyleguideMixin, DRFMixin, RichieCoursesConfigurationMixin, Configura
                     "label": _("Dashboard"),
                     "href": _("{base_url:s}/dashboard"),
                 },
+                "profile": {
+                    "label": _("Profile"),
+                    "href": _("{base_url:s}/u/(username)"),
+                },
                 "account": {
                     "label": _("Account"),
                     "href": _("{base_url:s}/account/settings"),
                 },
-                "profile": {
-                    "label": _("Profile"),
-                    "href": _("{base_url:s}/u/(username)"),
+                "order_history": {
+                    "label": _("Order History"),
+                    "href": _("{base_url:s}/orders/orders"),
                 },
             },
             environ_name="AUTHENTICATION_PROFILE_URLS",


### PR DESCRIPTION
This PR includes:
- In Portuguese language it was changed from Meus cursos to Painel de Cursos
- Changed menu items positions in accordance with lms

Due to the complexity of validating these changes being included by this PR, particularly regarding running LMS locally, the intention is to deploy to development environment and validate there if the requirements are met. 

This PR is related to:
- Change NAU Richie Menu entry order [#288](https://github.com/fccn/nau-richie-site-factory/issues/288)
- Add order history link to NAU Richie menu [#404](https://github.com/fccn/nau-technical/issues/404)
- Change NAU Richie Menu entry order [#288](https://github.com/fccn/nau-richie-site-factory/issues/288)