### PR TITLE
🔧(ap) add S3 default ACL and allow to configure  Django Storage from env

### DIFF
--- a/sites/ap/CHANGELOG.md
+++ b/sites/ap/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- 🔧(ap) allow to configure Django Storages from environment `DJANGO_STORAGES`
+
 ## [1.0.0] - 2025-03-06
 
 ### Added 

--- a/sites/ap/CHANGELOG.md
+++ b/sites/ap/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- 🔧(ap) add media S3 default ACL to `public-read`
 - 🔧(ap) allow to configure Django Storages from environment `DJANGO_STORAGES`
 
 ## [1.0.0] - 2025-03-06

--- a/sites/ap/src/backend/ap/settings.py
+++ b/sites/ap/src/backend/ap/settings.py
@@ -913,14 +913,31 @@ class Production(Base):
     # Use AWS S3 for media storage
     # DEFAULT_FILE_STORAGE = values.Value("storages.backends.s3boto3.S3Boto3Storage")
 
-    STORAGES = {
-        "default": {
-            "BACKEND": "storages.backends.s3boto3.S3Boto3Storage",
+    STORAGES = values.DictValue(
+        {
+            "default": {
+                "BACKEND": values.Value(
+                    "storages.backends.s3boto3.S3Boto3Storage",
+                    environ_name="STORAGES_DEFAULT_BACKEND",
+                ),
+                "OPTIONS": values.DictValue(
+                    {},
+                    environ_name="STORAGES_DEFAULT_OPTIONS",
+                ),
+            },
+            "staticfiles": {
+                "BACKEND": values.Value(
+                    "base.storage.CDNManifestStaticFilesStorage",
+                    environ_name="STORAGES_STATICFILES_BACKEND",
+                ),
+                "OPTIONS": values.DictValue(
+                    {},
+                    environ_name="STORAGES_STATICFILES_OPTIONS",
+                ),
+            },
         },
-        "staticfiles": {
-            "BACKEND": "base.storage.CDNManifestStaticFilesStorage",
-        },
-    }
+        environ_name="STORAGES",
+    )
 
     # Preprend all all media file paths on S3 bucket with 'media/'
     AWS_LOCATION = values.Value("media")

--- a/sites/ap/src/backend/ap/settings.py
+++ b/sites/ap/src/backend/ap/settings.py
@@ -967,6 +967,9 @@ class Production(Base):
     # Do not overwrite the files on the media S3 Bucket
     AWS_S3_FILE_OVERWRITE = values.Value(False)
 
+    # Write media files with public-read access
+    AWS_DEFAULT_ACL = values.Value("public-read")
+
     # CDN domain for static/media urls. It is passed to the frontend to load built chunks
     CDN_DOMAIN = values.Value()
 


### PR DESCRIPTION
🔧(ap) add S3 default ACL setting

Instead of having to change the default S3 bucket policy, just upload
the files with the public-read acl.

fccn/nau-technical#414

---------

🔧(ap) allow to configure  Django Storage from env

Allow to configure the Django `STORAGES` from an environment variable.
This gives the operator more flexibility instead of having to configure
all S3 parameters has environment variables, those can be configured per
storage directly on this new environment variable `DJANGO_STORAGES`.

fccn/nau-technical#414