### PR TITLE
🔧(nau) add S3 default ACL and allow to configure Django Storage from env

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -344,73 +344,73 @@ version: 2.1
 workflows:
     ap:
         jobs:
+            - no-change:
+                filters:
+                    tags:
+                        only: /.*/
+                name: no-change-ap
+    nau:
+        jobs:
             - check-changelog:
                 filters:
                     branches:
                         ignore: master
-                name: check-changelog-ap
-                site: ap
+                name: check-changelog-nau
+                site: nau
             - lint-changelog:
                 filters:
                     branches:
                         ignore: master
                     tags:
-                        only: /ap-.*/
-                name: lint-changelog-ap
-                site: ap
+                        only: /nau-.*/
+                name: lint-changelog-nau
+                site: nau
             - build-front-production:
                 filters:
                     tags:
-                        only: /ap-.*/
-                name: build-front-production-ap
-                site: ap
+                        only: /nau-.*/
+                name: build-front-production-nau
+                site: nau
             - lint-front:
                 filters:
                     tags:
-                        only: /ap-.*/
-                name: lint-front-ap
+                        only: /nau-.*/
+                name: lint-front-nau
                 requires:
-                    - build-front-production-ap
-                site: ap
+                    - build-front-production-nau
+                site: nau
             - build-back:
                 filters:
                     tags:
-                        only: /ap-.*/
-                name: build-back-ap
-                site: ap
+                        only: /nau-.*/
+                name: build-back-nau
+                site: nau
             - lint-back:
                 filters:
                     tags:
-                        only: /ap-.*/
-                name: lint-back-ap
+                        only: /nau-.*/
+                name: lint-back-nau
                 requires:
-                    - build-back-ap
-                site: ap
+                    - build-back-nau
+                site: nau
             - test-back:
                 filters:
                     tags:
-                        only: /ap-.*/
-                name: test-back-ap
+                        only: /nau-.*/
+                name: test-back-nau
                 requires:
-                    - build-back-ap
-                site: ap
+                    - build-back-nau
+                site: nau
             - hub:
                 filters:
                     tags:
-                        only: /^ap-.*/
-                image_name: ap
-                name: hub-ap
+                        only: /^nau-.*/
+                image_name: nau
+                name: hub-nau
                 requires:
-                    - lint-front-ap
-                    - lint-back-ap
-                site: ap
-    nau:
-        jobs:
-            - no-change:
-                filters:
-                    tags:
-                        only: /.*/
-                name: no-change-nau
+                    - lint-front-nau
+                    - lint-back-nau
+                site: nau
     site-factory:
         jobs:
             - lint-git:

--- a/env.d/development
+++ b/env.d/development
@@ -52,3 +52,5 @@ WEB_ANALYTICS={'google_universal_analytics': {'tracking_id': 'UA-123456789-1', '
 # Test CDN / static assets from different domain
 # DJANGO_STATIC_URL=https://nau-dev-richie-nau-static-assets.rgw.nau.fccn.pt/static/
 # DJANGO_CDN_DOMAIN=nau-dev-richie-nau-static-assets.rgw.nau.fccn.pt
+
+# DJANGO_STORAGES={'default': {'BACKEND': 'django.core.files.storage.FileSystemStorage'}, 'staticfiles': {'BACKEND': 'base.storage.CDNManifestStaticFilesStorage'} }

--- a/sites/nau/CHANGELOG.md
+++ b/sites/nau/CHANGELOG.md
@@ -12,6 +12,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - ✨(courses) script to extract courses data as csv format
 - 🧱(site-factory) added sites creation functionality
+- 🔧(nau) allow to configure Django Storages from environment `DJANGO_STORAGES`
 
 ### Fixed
 

--- a/sites/nau/CHANGELOG.md
+++ b/sites/nau/CHANGELOG.md
@@ -13,6 +13,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - ✨(courses) script to extract courses data as csv format
 - 🧱(site-factory) added sites creation functionality
 - 🔧(nau) allow to configure Django Storages from environment `DJANGO_STORAGES`
+- 🔧(nau) add media S3 default ACL to `public-read`
 
 ### Fixed
 

--- a/sites/nau/src/backend/nau/settings.py
+++ b/sites/nau/src/backend/nau/settings.py
@@ -813,14 +813,31 @@ class Production(Base):
     # Use AWS S3 for media storage
     # DEFAULT_FILE_STORAGE = values.Value("storages.backends.s3boto3.S3Boto3Storage")
 
-    STORAGES = {
-        "default": {
-            "BACKEND": "storages.backends.s3boto3.S3Boto3Storage",
+    STORAGES = values.DictValue(
+        {
+            "default": {
+                "BACKEND": values.Value(
+                    "storages.backends.s3boto3.S3Boto3Storage",
+                    environ_name="STORAGES_DEFAULT_BACKEND",
+                ),
+                "OPTIONS": values.DictValue(
+                    {},
+                    environ_name="STORAGES_DEFAULT_OPTIONS",
+                ),
+            },
+            "staticfiles": {
+                "BACKEND": values.Value(
+                    "base.storage.CDNManifestStaticFilesStorage",
+                    environ_name="STORAGES_STATICFILES_BACKEND",
+                ),
+                "OPTIONS": values.DictValue(
+                    {},
+                    environ_name="STORAGES_STATICFILES_OPTIONS",
+                ),
+            },
         },
-        "staticfiles": {
-            "BACKEND": "base.storage.CDNManifestStaticFilesStorage",
-        },
-    }
+        environ_name="STORAGES",
+    )
 
     # Preprend all all media file paths on S3 bucket with 'media/'
     AWS_LOCATION = values.Value("media")

--- a/sites/nau/src/backend/nau/settings.py
+++ b/sites/nau/src/backend/nau/settings.py
@@ -867,6 +867,9 @@ class Production(Base):
     # Do not overwrite the files on the media S3 Bucket
     AWS_S3_FILE_OVERWRITE = values.Value(False)
 
+    # Write media files with public-read access
+    AWS_DEFAULT_ACL = values.Value("public-read")
+
     # CDN domain for static/media urls. It is passed to the frontend to load built chunks
     CDN_DOMAIN = values.Value()
 


### PR DESCRIPTION
🔧(nau) add S3 default ACL setting

Instead of having to change the default S3 bucket policy, just upload
the files with the public-read acl.

https://github.com/fccn/nau-technical/issues/414

--------------

🔧(nau) allow to configure Django Storage from env

Allow to configure the Django STORAGES from an environment variable.
This gives the operator more flexibility instead of having to configure
all S3 parameters has environment variables, those can be configured per
storage directly on this new environment variable DJANGO_STORAGES.

https://github.com/fccn/nau-technical/issues/414