### PR TITLE
🔖(ap) bump to version 1.1.0

### DIFF
--- a/sites/ap/CHANGELOG.md
+++ b/sites/ap/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.1.0] - 2025-03-21
+
 ### Added
 
 - 🔧(ap) add media S3 default ACL to `public-read`

--- a/sites/ap/src/backend/ap/__init__.py
+++ b/sites/ap/src/backend/ap/__init__.py
@@ -1,2 +1,2 @@
 # pylint: disable=missing-module-docstring
-__version__ = "1.0.0"
+__version__ = "1.1.0"

--- a/sites/ap/src/frontend/package.json
+++ b/sites/ap/src/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ap",
-  "version": "1.0.0",
-  "description": "Richie NAU site on https://www.nau.edu.pt",
+  "version": "1.1.0",
+  "description": "Richie AP NAU site on https://ap.nau.edu.pt/",
   "scripts": {
     "build-sass": "sass scss/_main.scss ../backend/base/static/richie/css/main.css --load-path=node_modules",
     "build-sass-production": "sass scss/_main.scss ../backend/base/static/richie/css/main.css --style=compressed --load-path=node_modules",


### PR DESCRIPTION
Added

- 🔧(ap) add media S3 default ACL to `public-read`
- 🔧(ap) allow to configure Django Storages from environment `DJANGO_STORAGES`
- ✨(ap) added features to meet the first release requirements
    - Changed logo image
    - Removed english language and leave only portuguese
    - Set the missing variable `RICHIE_FILTERS_PRESENTATION` to have the filters working

Changed
- Updated the favicon and apple touch icon variants