### PR TITLE
🔖(nau) bump to version 2.0.0

### DIFF
--- a/sites/nau/CHANGELOG.md
+++ b/sites/nau/CHANGELOG.md
@@ -8,12 +8,15 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [2.0.0] - 2025-04-29
+
 ### Added
 
 - ✨(courses) script to extract courses data as csv format
 - 🧱(site-factory) added sites creation functionality
 - 🔧(nau) allow to configure Django Storages from environment `DJANGO_STORAGES`
 - 🔧(nau) add media S3 default ACL to `public-read`
+- ♿️(styles) add external link styles for accessibility
 
 ### Fixed
 
@@ -37,10 +40,6 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - ⚰️(maintenance) remove maintenance functionality
 - ✅(social) fix social share image test
 - ⬆️(nau) upgrade dependencies
-- 
-### Added
-
-- ♿️(styles) add external link styles for accessiblity
 
 ## [1.28.0] - 2024-06-21
 

--- a/sites/nau/src/backend/nau/__init__.py
+++ b/sites/nau/src/backend/nau/__init__.py
@@ -1,2 +1,2 @@
 # pylint: disable=missing-module-docstring
-__version__ = "1.28.0"
+__version__ = "2.0.0"

--- a/sites/nau/src/frontend/package.json
+++ b/sites/nau/src/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nau",
-  "version": "1.28.0",
+  "version": "2.0.0",
   "description": "Richie NAU site on https://www.nau.edu.pt",
   "scripts": {
     "build-sass": "sass scss/_main.scss ../backend/base/static/richie/css/main.css --load-path=node_modules",


### PR DESCRIPTION
Added

- ✨(courses) script to extract courses data as csv format
- 🧱(site-factory) added sites creation functionality
- 🔧(nau) allow to configure Django Storages from environment `DJANGO_STORAGES`
- 🔧(nau) add media S3 default ACL to `public-read`
- ♿️(styles) add external link styles for accessibility

Fixed

- 🐛(rdfa) fix RDFa Course errors on Google Search Console
- 🌐(i18n) review exiting force translations

Changed

- ⬆️(nau) upgrade richie to v2.32.0
- ⚰️(setttings) remove unused setting
- 💄(menu) on Portuguese language changed from Meus cursos to Painel de Cursos
- 💄(menu) changed menu items positions in accordance with lms
- ♿️(styles) remove extra h1 from blogpost
- ♿️(styles) add underline to icons
- ♿️(styles) set default font to 16px
- ♿️(styles) set footer link spacing to 44px height
- ♿️(styles) improve heading spacing in blogpost
- ⬆️(nau) upgrade richie to v3.0.0
- 🔥(video) remove lazy load video player
- 💄(rebranding) change NAU logo and styles for a rebrand of NAU
- ⚰️(maintenance) remove maintenance functionality
- ✅(social) fix social share image test
- ⬆️(nau) upgrade dependencies