### PR TITLE
👷(gitlint) fix gitlint warning

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -351,66 +351,11 @@ workflows:
                 name: no-change-ap
     nau:
         jobs:
-            - check-changelog:
-                filters:
-                    branches:
-                        ignore: master
-                name: check-changelog-nau
-                site: nau
-            - lint-changelog:
-                filters:
-                    branches:
-                        ignore: master
-                    tags:
-                        only: /nau-.*/
-                name: lint-changelog-nau
-                site: nau
-            - build-front-production:
+            - no-change:
                 filters:
                     tags:
-                        only: /nau-.*/
-                name: build-front-production-nau
-                site: nau
-            - lint-front:
-                filters:
-                    tags:
-                        only: /nau-.*/
-                name: lint-front-nau
-                requires:
-                    - build-front-production-nau
-                site: nau
-            - build-back:
-                filters:
-                    tags:
-                        only: /nau-.*/
-                name: build-back-nau
-                site: nau
-            - lint-back:
-                filters:
-                    tags:
-                        only: /nau-.*/
-                name: lint-back-nau
-                requires:
-                    - build-back-nau
-                site: nau
-            - test-back:
-                filters:
-                    tags:
-                        only: /nau-.*/
-                name: test-back-nau
-                requires:
-                    - build-back-nau
-                site: nau
-            - hub:
-                filters:
-                    tags:
-                        only: /^nau-.*/
-                image_name: nau
-                name: hub-nau
-                requires:
-                    - lint-front-nau
-                    - lint-back-nau
-                site: nau
+                        only: /.*/
+                name: no-change-nau
     site-factory:
         jobs:
             - lint-git:

--- a/.gitlint
+++ b/.gitlint
@@ -1,5 +1,7 @@
 # All these sections are optional, edit this file as you like.
 [general]
+regex-style-search=true
+
 # Ignore certain rules, you can reference them by their id or by their full name
 # ignore=title-trailing-punctuation, T3
 


### PR DESCRIPTION
This commit re-configures the gitlint so it no longer outputs a warning.

WARNING: I1 - ignore-by-title: gitlint will be switching from using Python regex 'match' (match beginning) to 'search' (match anywhere) semantics. Please review your ignore-by-title.regex option accordingly. To remove this warning, set general.regex-style-search=True. More details:
https://jorisroovers.github.io/gitlint/configuration/#regex-style-search