### PR TITLE
⬆️(nau) upgrade richie to v3.1.2

### DIFF
--- a/sites/nau/CHANGELOG.md
+++ b/sites/nau/CHANGELOG.md
@@ -21,6 +21,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - ⬆️(nau) upgrade richie to v3.1.0
+- ⬆️(nau) upgrade richie to v3.1.2
 
 ## [2.1.0] - 2025-05-02
 

--- a/sites/nau/requirements/base.txt
+++ b/sites/nau/requirements/base.txt
@@ -7,7 +7,7 @@ dockerflow==2024.4.2
 factory-boy==3.3.3
 gunicorn==23.0.0
 psycopg2-binary==2.9.10
-richie==3.1.0
+richie==3.1.2
 sentry-sdk==2.24.1
 mysqlclient==2.2.7
 # Remove django-cms dep when upgrading to richie 2.25.0

--- a/sites/nau/src/frontend/package.json
+++ b/sites/nau/src/frontend/package.json
@@ -34,7 +34,7 @@
   },
   "homepage": "https://github.com/fccn/nau-richie-site-factory#readme",
   "dependencies": {
-    "richie-education": "3.1.0",
+    "richie-education": "3.1.2",
     "source-map-loader": "4.0.1"
   },
   "devDependencies": {

--- a/sites/nau/src/frontend/yarn.lock
+++ b/sites/nau/src/frontend/yarn.lock
@@ -10801,10 +10801,10 @@ reusify@^1.0.4:
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
   integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
 
-richie-education@3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/richie-education/-/richie-education-3.1.0.tgz#ba3e842e8ae38f6db1adeaf18dacb87b85531709"
-  integrity sha512-myGVFbA9Idpi3CM/vqSNjBELwQIO8RhbJEjzZDLyD2ZVmrlNGjGidxhA5TMNpDvH7Fh5rJST2q33tq4lQLwYKw==
+richie-education@3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/richie-education/-/richie-education-3.1.2.tgz#733251076e9229549af722b080e413a6fd427e84"
+  integrity sha512-lAug7SU3esY3vm726anjn55mVuSfDC0fJ0wF8OVmRww8Ti0Ep06KR1RVErp8rCx4imU4urnZsAVX4c6/8EVhFw==
   dependencies:
     "@babel/core" "7.26.10"
     "@babel/plugin-syntax-dynamic-import" "7.8.3"


### PR DESCRIPTION
Changelog available at:
https://github.com/openfun/richie/releases/tag/v3.1.2

Related to [Upgrade NAU Richie #561](https://github.com/fccn/nau-technical/issues/561)