### PR TITLE
⬆️(ap) upgrade richie to v3.1.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -344,73 +344,73 @@ version: 2.1
 workflows:
     ap:
         jobs:
-            - no-change:
-                filters:
-                    tags:
-                        only: /.*/
-                name: no-change-ap
-    nau:
-        jobs:
             - check-changelog:
                 filters:
                     branches:
                         ignore: master
-                name: check-changelog-nau
-                site: nau
+                name: check-changelog-ap
+                site: ap
             - lint-changelog:
                 filters:
                     branches:
                         ignore: master
                     tags:
-                        only: /nau-.*/
-                name: lint-changelog-nau
-                site: nau
+                        only: /ap-.*/
+                name: lint-changelog-ap
+                site: ap
             - build-front-production:
                 filters:
                     tags:
-                        only: /nau-.*/
-                name: build-front-production-nau
-                site: nau
+                        only: /ap-.*/
+                name: build-front-production-ap
+                site: ap
             - lint-front:
                 filters:
                     tags:
-                        only: /nau-.*/
-                name: lint-front-nau
+                        only: /ap-.*/
+                name: lint-front-ap
                 requires:
-                    - build-front-production-nau
-                site: nau
+                    - build-front-production-ap
+                site: ap
             - build-back:
                 filters:
                     tags:
-                        only: /nau-.*/
-                name: build-back-nau
-                site: nau
+                        only: /ap-.*/
+                name: build-back-ap
+                site: ap
             - lint-back:
                 filters:
                     tags:
-                        only: /nau-.*/
-                name: lint-back-nau
+                        only: /ap-.*/
+                name: lint-back-ap
                 requires:
-                    - build-back-nau
-                site: nau
+                    - build-back-ap
+                site: ap
             - test-back:
                 filters:
                     tags:
-                        only: /nau-.*/
-                name: test-back-nau
+                        only: /ap-.*/
+                name: test-back-ap
                 requires:
-                    - build-back-nau
-                site: nau
+                    - build-back-ap
+                site: ap
             - hub:
                 filters:
                     tags:
-                        only: /^nau-.*/
-                image_name: nau
-                name: hub-nau
+                        only: /^ap-.*/
+                image_name: ap
+                name: hub-ap
                 requires:
-                    - lint-front-nau
-                    - lint-back-nau
-                site: nau
+                    - lint-front-ap
+                    - lint-back-ap
+                site: ap
+    nau:
+        jobs:
+            - no-change:
+                filters:
+                    tags:
+                        only: /.*/
+                name: no-change-nau
     site-factory:
         jobs:
             - lint-git:

--- a/sites/ap/CHANGELOG.md
+++ b/sites/ap/CHANGELOG.md
@@ -14,6 +14,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - ⬆️(ap) upgrade dependencies
 - 🔧(ap) update settings w/ site cookiecutter
 - ⚰️(maintenance) remove maintenance functionality
+- ⬆️(ap) upgrade richie to v3.1.2
 
 ## [1.2.1] - 2025-04-16
 

--- a/sites/ap/requirements/base.txt
+++ b/sites/ap/requirements/base.txt
@@ -7,7 +7,7 @@ dockerflow==2024.4.2
 factory-boy==3.3.3
 gunicorn==23.0.0
 psycopg2-binary==2.9.10
-richie==3.0.0
+richie==3.1.2
 sentry-sdk==2.24.1
 mysqlclient==2.2.7
 # Remove django-cms dep when upgrading to richie 2.25.0

--- a/sites/ap/src/frontend/package.json
+++ b/sites/ap/src/frontend/package.json
@@ -34,7 +34,7 @@
   },
   "homepage": "https://github.com/fccn/nau-richie-site-factory#readme",
   "dependencies": {
-    "richie-education": "3.0.0",
+    "richie-education": "3.1.2",
     "source-map-loader": "4.0.1"
   },
   "devDependencies": {

--- a/sites/ap/src/frontend/yarn.lock
+++ b/sites/ap/src/frontend/yarn.lock
@@ -10801,10 +10801,10 @@ reusify@^1.0.4:
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
   integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
 
-richie-education@3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/richie-education/-/richie-education-3.0.0.tgz#7aa8ac34da7fd0040e90cf0693443de4e3771554"
-  integrity sha512-fmSrU+/tUpkwGRDFCahsOYKVjWqbzjBlvB23/2lu4dKOJZabVjKQGRbYcAabnB24qHV/zNDDVT8s02ObO2e9iA==
+richie-education@3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/richie-education/-/richie-education-3.1.2.tgz#733251076e9229549af722b080e413a6fd427e84"
+  integrity sha512-lAug7SU3esY3vm726anjn55mVuSfDC0fJ0wF8OVmRww8Ti0Ep06KR1RVErp8rCx4imU4urnZsAVX4c6/8EVhFw==
   dependencies:
     "@babel/core" "7.26.10"
     "@babel/plugin-syntax-dynamic-import" "7.8.3"


### PR DESCRIPTION
Changelog available at:
https://github.com/openfun/richie/releases/tag/v3.1.2

Related to [Upgrade NAU Richie #561](https://github.com/fccn/nau-technical/issues/561)