### PR TITLE
🔖(ap) bump to version 1.3.0

### DIFF
--- a/sites/ap/CHANGELOG.md
+++ b/sites/ap/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.3.0] - 2025-07-02
+
 ### Changed
 
 - 🔥(video) remove lazy load video player

--- a/sites/ap/src/backend/ap/__init__.py
+++ b/sites/ap/src/backend/ap/__init__.py
@@ -1,2 +1,2 @@
 # pylint: disable=missing-module-docstring
-__version__ = "1.2.1"
+__version__ = "1.3.0"

--- a/sites/ap/src/frontend/package.json
+++ b/sites/ap/src/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ap",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "Richie AP NAU site on https://ap.nau.edu.pt/",
   "scripts": {
     "build-sass": "sass scss/_main.scss ../backend/base/static/richie/css/main.css --load-path=node_modules",


### PR DESCRIPTION
Changed

- 🔥(video) remove lazy load video player
- ⬆️(ap) upgrade dependencies
- 🔧(ap) update settings w/ site cookiecutter
- ⚰️(maintenance) remove maintenance functionality
- ⬆️(ap) upgrade richie to v3.1.2

Fixed

- 🐛(ap) added homepage logo link to the header