### PR TITLE
⬆️(deps) update python dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -169,7 +169,7 @@ test-back: .env ## run back-end tests: `make test-back ARGS="--reuse-db"` or a s
 .PHONY: test-back
 
 test-front: ## run front-end tests
-       @$(YARN) test --runInBand
+	@$(YARN) jest --runInBand
 .PHONY: test-front
 
 watch-sass: .env ## watch changes in Sass files

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ COLOR_RESET   = \033[0m
 DOCKER_UID           = $(shell id -u)
 DOCKER_GID           = $(shell id -g)
 NGINX_IMAGE_NAME     = nginx
-NGINX_IMAGE_TAG      = 1.29.6
+NGINX_IMAGE_TAG      = 1.31.0
 
 COMPOSE              = \
   NGINX_IMAGE_NAME="$(NGINX_IMAGE_NAME)" \

--- a/sites/ap/CHANGELOG.md
+++ b/sites/ap/CHANGELOG.md
@@ -20,6 +20,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - 🔨(deps) add missing pbr dev dependency for bandit
 - 🐛(deps) upgrade raincoat to 1.2.4 for Python 3.11 compatibility
 - 💄(course) change heading font size on course page
+- ⬆️(deps) update python dependencies
 
 ### Fixed
 

--- a/sites/ap/requirements/base.txt
+++ b/sites/ap/requirements/base.txt
@@ -1,17 +1,17 @@
-boto3==1.28.9
+boto3==1.43.8
 django-check-seo==0.6.4
 richie==3.4.0
 unidecode==1.3.6 # required by django-check-seo
 django-configurations==2.5.1
 # Superior versions of django-storages are not compatible with
 # ManifestStaticFilesStorage
-django-storages==1.14.5
-dockerflow==2024.4.2
+django-storages==1.14.6
+dockerflow==2026.3.4
 factory-boy==3.3.3
-gunicorn==23.0.0
-psycopg2-binary==2.9.10
-sentry-sdk==2.24.1
-mysqlclient==2.2.7
+gunicorn==26.0.0
+psycopg2-binary==2.9.12
+sentry-sdk==2.60.0
+mysqlclient==2.2.8
 # Remove django-cms dep when upgrading to richie 2.25.0
 # django-cms>=3.11.0,<4.0.0
 # Plugins

--- a/sites/ap/requirements/dev.txt
+++ b/sites/ap/requirements/dev.txt
@@ -1,18 +1,17 @@
-bandit==1.7.5
-black==24.3.0
+bandit==1.8.3
+black==25.1.0
 Faker==35.2.0
 factory-boy==3.3.3
-flake8==6.0.0
-pbr>=5.5.0
+flake8==7.2.0
 flake8-pyproject==1.2.3
-isort==5.12.0
-pylint==2.17.4
-pylint-django==2.5.3
+isort==6.0.1
+pylint==3.3.6
+pylint-django==2.6.1
 pytest==7.4.0
-pytest-cov==4.1.0
-pytest-django==4.5.2
+pytest-cov==6.0.0
+pytest-django==4.10.0
 raincoat==1.2.4
 
 # Testing html
-lxml==4.9.3
-cssselect==1.2.0
+lxml==5.3.1
+cssselect==1.3.0

--- a/sites/ap/src/backend/ap/settings.py
+++ b/sites/ap/src/backend/ap/settings.py
@@ -18,6 +18,11 @@ from sentry_sdk.integrations.logging import ignore_logger
 # pylint: disable=import-error
 from base.utils import merge_dict
 
+# AWS checksum validation configuration (required for boto3 >= 1.28.0)
+# Required to use compatible S3 storage backends like Ceph.
+os.environ["AWS_REQUEST_CHECKSUM_CALCULATION"] = "when_required"
+os.environ["AWS_RESPONSE_CHECKSUM_VALIDATION"] = "when_required"
+
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 DATA_DIR = os.path.join("/", "data")
 

--- a/sites/ap/src/backend/base/cache.py
+++ b/sites/ap/src/backend/base/cache.py
@@ -1,9 +1,9 @@
 """
-    RedisCache with a fallback cache to prevent denial of service if Redis is down
-    Freely inspired by django-cache-fallback
+RedisCache with a fallback cache to prevent denial of service if Redis is down
+Freely inspired by django-cache-fallback
 
-    Credits:
-    - https://github.com/Kub-AT/django-cache-fallback/
+Credits:
+- https://github.com/Kub-AT/django-cache-fallback/
 """
 
 import logging

--- a/sites/nau/CHANGELOG.md
+++ b/sites/nau/CHANGELOG.md
@@ -21,6 +21,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - 🐛(deps) upgrade raincoat to 1.2.4 for Python 3.11 compatibility
 - 💄(course) change heading font size on course page
 - 💄(social) change social networks share logo
+- ⬆️(deps) update python dependencies
 
 ### Added
 

--- a/sites/nau/requirements/base.txt
+++ b/sites/nau/requirements/base.txt
@@ -1,17 +1,17 @@
-boto3==1.28.9
+boto3==1.43.8
 django-check-seo==0.6.4
 richie==3.4.0
 unidecode==1.3.6 # required by django-check-seo
 django-configurations==2.5.1
 # Superior versions of django-storages are not compatible with
 # ManifestStaticFilesStorage
-django-storages==1.14.5
-dockerflow==2024.4.2
+django-storages==1.14.6
+dockerflow==2026.3.4
 factory-boy==3.3.3
-gunicorn==23.0.0
-psycopg2-binary==2.9.10
-sentry-sdk==2.24.1
-mysqlclient==2.2.7
+gunicorn==26.0.0
+psycopg2-binary==2.9.12
+sentry-sdk==2.60.0
+mysqlclient==2.2.8
 # Remove django-cms dep when upgrading to richie 2.25.0
 # django-cms>=3.11.0,<4.0.0
 # Plugins

--- a/sites/nau/requirements/dev.txt
+++ b/sites/nau/requirements/dev.txt
@@ -1,18 +1,17 @@
-bandit==1.7.5
-black==24.3.0
+bandit==1.8.3
+black==25.1.0
 Faker==35.2.0
 factory-boy==3.3.3
-flake8==6.0.0
-pbr>=5.5.0
+flake8==7.2.0
 flake8-pyproject==1.2.3
-isort==5.12.0
-pylint==2.17.4
-pylint-django==2.5.3
+isort==6.0.1
+pylint==3.3.6
+pylint-django==2.6.1
 pytest==7.4.0
-pytest-cov==4.1.0
-pytest-django==4.5.2
+pytest-cov==6.0.0
+pytest-django==4.10.0
 raincoat==1.2.4
 
 # Testing html
-lxml==4.9.3
-cssselect==1.2.0
+lxml==5.3.1
+cssselect==1.3.0

--- a/sites/nau/src/backend/base/cache.py
+++ b/sites/nau/src/backend/base/cache.py
@@ -1,9 +1,9 @@
 """
-    RedisCache with a fallback cache to prevent denial of service if Redis is down
-    Freely inspired by django-cache-fallback
+RedisCache with a fallback cache to prevent denial of service if Redis is down
+Freely inspired by django-cache-fallback
 
-    Credits:
-    - https://github.com/Kub-AT/django-cache-fallback/
+Credits:
+- https://github.com/Kub-AT/django-cache-fallback/
 """
 
 import logging

--- a/sites/nau/src/backend/nau/settings.py
+++ b/sites/nau/src/backend/nau/settings.py
@@ -17,6 +17,11 @@ from sentry_sdk.integrations.logging import ignore_logger
 # pylint: disable=import-error
 from base.utils import merge_dict
 
+# AWS checksum validation configuration (required for boto3 >= 1.28.0)
+# Required to use compatible S3 storage backends like Ceph.
+os.environ["AWS_REQUEST_CHECKSUM_CALCULATION"] = "when_required"
+os.environ["AWS_RESPONSE_CHECKSUM_VALIDATION"] = "when_required"
+
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 DATA_DIR = os.path.join("/", "data")
 


### PR DESCRIPTION
Update the backend Python dependencies.
Newer versions of boto3 requires an workaround to work with compatible S3 installations like Ceph.