### PR TITLE
🐛(nau,ap) fix sitemap timeout, robots.txt, canonical, hreflang

### DIFF
--- a/sites/ap/CHANGELOG.md
+++ b/sites/ap/CHANGELOG.md
@@ -8,6 +8,32 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- 🐛(ap) cache sitemap.xml response to avoid crawler timeouts
+  The sitemap.xml endpoint was rebuilt from the database on every request,
+  which was slow enough to make search engine crawlers time out. Wrap the
+  view with Django's cache_page (configurable via SITEMAP_CACHE_TIMEOUT,
+  defaults to 24h) so it is served instantly after the first request.
+- 🐛(ap) serve https:// URLs in sitemap.xml and robots.txt behind the proxy
+  The app sits behind a reverse proxy that terminates TLS and forwards plain
+  HTTP, so request.is_secure() always evaluated to False. Configure
+  SECURE_PROXY_SSL_HEADER so the sitemap's <loc> entries and the robots.txt
+  "Sitemap:" line correctly advertise https:// instead of http://.
+- 🐛(ap) disallow crawling of parameterized URLs in robots.txt
+  Query-string URLs (pagination on detail pages, client-side search filters,
+  tracking params...) are not unique indexable content; all real content
+  already lives at clean, path-based URLs covered by the sitemap. Add
+  `Disallow: *?*` to reduce crawl budget waste and duplicate content
+  discovery.
+- 🐛(ap) add self-referencing canonical tag to every indexable page
+  Pages had no canonical tag, risking duplicate-content signals across
+  paginated, filtered and query-string URL variants. Add a self-referencing
+  `<link rel="canonical">` (built from the same https-aware SITE.web_url used
+  by the sitemap/robots.txt fixes) pointing to the clean, absolute URL of the
+  current page, with query strings excluded so pagination/search-filter
+  variants consolidate onto the canonical page.
+
 ## [1.5.0] - 2026-05-15
 
 ### Changed

--- a/sites/ap/src/backend/ap/settings.py
+++ b/sites/ap/src/backend/ap/settings.py
@@ -661,6 +661,13 @@ class Base(StyleguideMixin, DRFMixin, RichieCoursesConfigurationMixin, Configura
         {"menus": 3600, "content": 60, "permissions": 3600}
     )
 
+    # Cache duration (in seconds) for the dynamically generated sitemap.xml view.
+    # Without caching, the sitemap is rebuilt from the database on every request,
+    # which is slow enough to make search engine crawlers time out. Defaults to 24h.
+    SITEMAP_CACHE_TIMEOUT = values.IntegerValue(
+        86400, environ_name="SITEMAP_CACHE_TIMEOUT", environ_prefix=None
+    )
+
     # Sessions
     SESSION_ENGINE = values.Value("django.contrib.sessions.backends.cache")
 
@@ -959,6 +966,12 @@ class Production(Base):
     CSRF_COOKIE_SECURE = True
     CSRF_TRUSTED_ORIGINS = values.ListValue([])
     CSRF_COOKIE_DOMAIN = values.Value(None)
+    # The app sits behind an nginx-ingress (or similar reverse proxy) that terminates
+    # TLS and forwards requests over plain HTTP. Without this, request.is_secure()
+    # (and request.scheme) always evaluate to False/"http", which made the sitemap's
+    # <loc> entries and the robots.txt "Sitemap:" line advertise http:// URLs even
+    # though the site is only ever served over https in production.
+    SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
     SECURE_BROWSER_XSS_FILTER = True
     SECURE_CONTENT_TYPE_NOSNIFF = True
     SESSION_COOKIE_SECURE = True

--- a/sites/ap/src/backend/ap/tests/test_canonical.py
+++ b/sites/ap/src/backend/ap/tests/test_canonical.py
@@ -1,0 +1,85 @@
+"""
+Test suite for the self-referencing canonical URL tag.
+"""
+
+from django.conf import settings
+from django.test import TestCase, override_settings
+
+from cms.api import create_page
+from richie.apps.courses.factories import CourseFactory
+
+
+class CanonicalUrlTestCase(TestCase):
+    """Ensure indexable pages expose a correct, self-referencing canonical tag."""
+
+    def test_homepage_has_self_referencing_canonical(self):
+        """The homepage should carry a canonical tag pointing to itself."""
+        page = create_page(
+            "Home",
+            "richie/homepage.html",
+            settings.LANGUAGE_CODE,
+            published=True,
+        )
+        page.set_as_homepage()
+
+        response = self.client.get(page.get_absolute_url())
+
+        self.assertContains(
+            response,
+            f'<link rel="canonical" href="http://example.com{page.get_absolute_url()}" />',
+        )
+
+    def test_course_detail_page_canonical_matches_its_own_clean_url(self):
+        """
+        A course detail page's canonical must point to its own clean URL - not the
+        organization/category listing it's linked from, and not a redirected variant.
+        """
+        course = CourseFactory()
+        course.extended_object.publish(settings.LANGUAGE_CODE)
+        page = course.extended_object
+
+        response = self.client.get(page.get_absolute_url())
+
+        self.assertContains(
+            response,
+            f'<link rel="canonical" href="http://example.com{page.get_absolute_url()}" />',
+        )
+
+    def test_canonical_strips_pagination_query_string(self):
+        """
+        Visiting a detail page with a pagination query string (e.g. paginating an
+        embedded course listing) must still canonicalize to the clean, unparameterized
+        URL - consolidating ranking signals onto a single indexable version.
+        """
+        course = CourseFactory()
+        course.extended_object.publish(settings.LANGUAGE_CODE)
+        page = course.extended_object
+        clean_url = page.get_absolute_url()
+
+        response = self.client.get(f"{clean_url}?page_courses=2")
+
+        self.assertContains(
+            response,
+            f'<link rel="canonical" href="http://example.com{clean_url}" />',
+        )
+        self.assertNotContains(response, "page_courses=2")
+
+    def test_canonical_uses_https_behind_proxy(self):
+        """
+        The reverse proxy in front of this app terminates TLS and forwards plain
+        HTTP. With SECURE_PROXY_SSL_HEADER configured (Production settings), the
+        canonical URL must use https:// (the scheme the crawler actually requested),
+        not the internal http:// one.
+        """
+        course = CourseFactory()
+        course.extended_object.publish(settings.LANGUAGE_CODE)
+        page = course.extended_object
+
+        with override_settings(
+            SECURE_PROXY_SSL_HEADER=("HTTP_X_FORWARDED_PROTO", "https")
+        ):
+            response = self.client.get(
+                page.get_absolute_url(), HTTP_X_FORWARDED_PROTO="https"
+            )
+
+        self.assertContains(response, 'rel="canonical" href="https://')

--- a/sites/ap/src/backend/ap/tests/test_canonical.py
+++ b/sites/ap/src/backend/ap/tests/test_canonical.py
@@ -3,9 +3,12 @@ Test suite for the self-referencing canonical URL tag.
 """
 
 from django.conf import settings
+from django.contrib.auth.models import AnonymousUser
 from django.test import TestCase, override_settings
+from django.test.client import RequestFactory
 
 from cms.api import create_page
+from richie.apps.core.views import error
 from richie.apps.courses.factories import CourseFactory
 
 
@@ -83,3 +86,18 @@ class CanonicalUrlTestCase(TestCase):
             )
 
         self.assertContains(response, 'rel="canonical" href="https://')
+
+    def test_no_canonical_tag_on_error_pages(self):
+        """
+        Richie's 404/error handler renders richie/error.html with no current_page
+        in its request/context - there's no single "correct" URL to canonicalize
+        an error response onto, so the guard in base.html's meta_html block must
+        suppress the canonical tag entirely rather than render a broken/empty href.
+        """
+        request = RequestFactory().get("/this-page-does-not-exist/")
+        request.user = AnonymousUser()
+        request.current_page = None
+
+        response = error.error_404_view_handler(request, Exception)
+
+        self.assertNotContains(response, 'rel="canonical"', status_code=404)

--- a/sites/ap/src/backend/ap/tests/test_robots.py
+++ b/sites/ap/src/backend/ap/tests/test_robots.py
@@ -1,0 +1,41 @@
+"""
+Test suite for the robots.txt view.
+"""
+
+from django.test import TestCase, override_settings
+
+
+class RobotsTxtTestCase(TestCase):
+    """Ensure robots.txt is served correctly and advertises the right crawl rules."""
+
+    def test_robots_txt_returns_200_plain_text(self):
+        """The robots.txt endpoint should respond successfully as plain text."""
+        response = self.client.get("/robots.txt")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["Content-Type"], "text/plain")
+
+    def test_robots_txt_disallows_parameterized_urls(self):
+        """
+        Query-string URLs (pagination on detail pages, client-side search filters,
+        UTM tracking params...) are not unique indexable content on this site - all
+        real content lives at clean, path-based URLs already listed in the sitemap.
+        Crawling them wastes crawl budget and can surface near-duplicate content.
+        """
+        response = self.client.get("/robots.txt")
+
+        self.assertContains(response, "Disallow: *?*")
+
+    def test_robots_txt_sitemap_reference_uses_https_behind_proxy(self):
+        """
+        The reverse proxy in front of this app terminates TLS and forwards plain
+        HTTP, setting an X-Forwarded-Proto header. With SECURE_PROXY_SSL_HEADER
+        configured (Production settings), the Sitemap: line must reflect the
+        original https:// scheme instead of the internal http:// one.
+        """
+        with override_settings(
+            SECURE_PROXY_SSL_HEADER=("HTTP_X_FORWARDED_PROTO", "https")
+        ):
+            response = self.client.get("/robots.txt", HTTP_X_FORWARDED_PROTO="https")
+
+        self.assertContains(response, "Sitemap: https://")

--- a/sites/ap/src/backend/ap/tests/test_sitemap.py
+++ b/sites/ap/src/backend/ap/tests/test_sitemap.py
@@ -1,0 +1,77 @@
+"""
+Test suite for the cached sitemap.xml view.
+"""
+
+from unittest import mock
+
+from django.conf import settings
+from django.core.cache import cache
+from django.test import TestCase, override_settings
+
+from cms.sitemaps import CMSSitemap
+from richie.apps.courses.factories import CourseFactory
+
+
+@override_settings(
+    CACHES={"default": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"}},
+    SITEMAP_CACHE_TIMEOUT=86400,
+)
+class SitemapCacheTestCase(TestCase):
+    """Ensure sitemap.xml is served from cache instead of being rebuilt on every request."""
+
+    def setUp(self):
+        super().setUp()
+        cache.clear()
+        course = CourseFactory()
+        course.extended_object.publish(settings.LANGUAGE_CODE)
+
+    def test_sitemap_returns_200_xml(self):
+        """The sitemap endpoint should respond successfully with an XML document."""
+        response = self.client.get("/sitemap.xml")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["Content-Type"], "application/xml")
+
+    def test_sitemap_generation_is_not_repeated_on_second_request(self):
+        """
+        A second request within the cache timeout should be served entirely from
+        cache: the (expensive) sitemap generation itself must only run once, no
+        matter how many times crawlers hit the endpoint in that window.
+        """
+        with mock.patch.object(
+            CMSSitemap, "items", wraps=CMSSitemap.items, autospec=True
+        ) as mocked_items:
+            first_response = self.client.get("/sitemap.xml")
+            second_response = self.client.get("/sitemap.xml")
+
+        self.assertEqual(first_response.status_code, 200)
+        self.assertEqual(second_response.status_code, 200)
+        self.assertEqual(
+            mocked_items.call_count,
+            1,
+            "Sitemap generation should only run once for both requests; the second "
+            "request should be served from cache",
+        )
+        self.assertEqual(first_response.content, second_response.content)
+
+    def test_sitemap_sets_cache_control_header(self):
+        """The cached view should set a Cache-Control header advertising its lifetime."""
+        response = self.client.get("/sitemap.xml")
+
+        self.assertIn("Cache-Control", response)
+        self.assertIn("max-age=", response["Cache-Control"])
+
+    def test_sitemap_urls_use_https_behind_proxy(self):
+        """
+        The reverse proxy in front of this app terminates TLS and forwards plain
+        HTTP, setting an X-Forwarded-Proto header. With SECURE_PROXY_SSL_HEADER
+        configured (Production settings), <loc> entries must use https:// (the
+        scheme the crawler actually requested), not the internal http:// one.
+        """
+        with override_settings(
+            SECURE_PROXY_SSL_HEADER=("HTTP_X_FORWARDED_PROTO", "https")
+        ):
+            response = self.client.get("/sitemap.xml", HTTP_X_FORWARDED_PROTO="https")
+
+        self.assertContains(response, "<loc>https://")
+        self.assertNotContains(response, "<loc>http://")

--- a/sites/ap/src/backend/ap/tests/test_sitemap.py
+++ b/sites/ap/src/backend/ap/tests/test_sitemap.py
@@ -2,6 +2,7 @@
 Test suite for the cached sitemap.xml view.
 """
 
+import re
 from unittest import mock
 
 from django.conf import settings
@@ -75,3 +76,24 @@ class SitemapCacheTestCase(TestCase):
 
         self.assertContains(response, "<loc>https://")
         self.assertNotContains(response, "<loc>http://")
+
+    def test_sitemap_never_relies_on_query_string_urls(self):
+        """
+        robots.txt's "Disallow: *?*" rule (fccn/nau-technical#991) blocks crawling
+        of any query-string URL (pagination, search filters, UTM params). This is
+        only safe because every indexable page already has a clean, path-based URL
+        the sitemap can point crawlers to: no page in this site is reachable *only*
+        via a query-string URL. If that ever stopped being true, the sitemap itself
+        would be the first place it broke - a <loc> entry containing "?" would mean
+        real content is being both advertised for indexing and disallowed from
+        crawling at the same time.
+        """
+        response = self.client.get("/sitemap.xml")
+
+        for loc in re.findall(rb"<loc>([^<]+)</loc>", response.content):
+            self.assertNotIn(
+                b"?",
+                loc,
+                f"Sitemap entry {loc} contains a query string, which would make "
+                "it unreachable under robots.txt's Disallow: *?* rule",
+            )

--- a/sites/ap/src/backend/ap/urls.py
+++ b/sites/ap/src/backend/ap/urls.py
@@ -8,6 +8,7 @@ from django.contrib import admin
 from django.contrib.sitemaps.views import sitemap
 from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 from django.urls import include, path, re_path
+from django.views.decorators.cache import cache_page
 from django.views.generic import TemplateView
 from django.views.static import serve
 
@@ -37,7 +38,14 @@ urlpatterns = [
             template_name="richie/robots.html", content_type="text/plain"
         ),
     ),
-    path(r"sitemap.xml", sitemap, {"sitemaps": {"cmspages": CMSSitemap}}),
+    # Cache the sitemap for 24h so crawlers get an immediate response instead of
+    # triggering a full dynamic sitemap generation (and its DB queries) on every
+    # request, which was causing crawler timeouts.
+    path(
+        r"sitemap.xml",
+        cache_page(settings.SITEMAP_CACHE_TIMEOUT)(sitemap),
+        {"sitemaps": {"cmspages": CMSSitemap}},
+    ),
     re_path(
         rf"api/{API_PREFIX}/",
         include([*courses_urlpatterns, *search_urlpatterns, *plugins_urlpatterns]),

--- a/sites/ap/src/backend/templates/richie/base.html
+++ b/sites/ap/src/backend/templates/richie/base.html
@@ -13,7 +13,7 @@
 <meta name="theme-color" content="#ffffff">
 {% endblock meta_favicons %}
 
-{% block meta_hreflang %}
+{% block meta_html %}
 {{ block.super }}
 {% if current_page %}
 {# Self-referencing canonical URL. Query strings (pagination, search filters) are #}
@@ -21,7 +21,7 @@
 {# the clean page-1 URL, per the platform's canonical URL strategy. #}
 <link rel="canonical" href="{{ SITE.web_url }}{{ current_page.get_absolute_url }}" />
 {% endif %}
-{% endblock meta_hreflang %}
+{% endblock meta_html %}
 
 {% block meta_rdfa_context %}
     <meta property="og:type" content="website" />

--- a/sites/ap/src/backend/templates/richie/base.html
+++ b/sites/ap/src/backend/templates/richie/base.html
@@ -13,6 +13,16 @@
 <meta name="theme-color" content="#ffffff">
 {% endblock meta_favicons %}
 
+{% block meta_hreflang %}
+{{ block.super }}
+{% if current_page %}
+{# Self-referencing canonical URL. Query strings (pagination, search filters) are #}
+{# intentionally excluded so paginated/filtered variants of a page canonicalize to #}
+{# the clean page-1 URL, per the platform's canonical URL strategy. #}
+<link rel="canonical" href="{{ SITE.web_url }}{{ current_page.get_absolute_url }}" />
+{% endif %}
+{% endblock meta_hreflang %}
+
 {% block meta_rdfa_context %}
     <meta property="og:type" content="website" />
     <meta property="og:image" content="{% static_absolute "richie/images/og_media_geral_fb_22a.png" %}"/>

--- a/sites/ap/src/backend/templates/richie/robots.html
+++ b/sites/ap/src/backend/templates/richie/robots.html
@@ -1,0 +1,3 @@
+User-Agent: *
+Disallow: *?*
+Sitemap: {{ SITE.web_url }}/sitemap.xml

--- a/sites/nau/CHANGELOG.md
+++ b/sites/nau/CHANGELOG.md
@@ -8,6 +8,38 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- 🐛(nau) cache sitemap.xml response to avoid crawler timeouts
+  The sitemap.xml endpoint was rebuilt from the database on every request,
+  which was slow enough to make search engine crawlers time out. Wrap the
+  view with Django's cache_page (configurable via SITEMAP_CACHE_TIMEOUT,
+  defaults to 24h) so it is served instantly after the first request.
+- 🐛(nau) serve https:// URLs in sitemap.xml and robots.txt behind the proxy
+  The app sits behind a reverse proxy that terminates TLS and forwards plain
+  HTTP, so request.is_secure() always evaluated to False. Configure
+  SECURE_PROXY_SSL_HEADER so the sitemap's <loc> entries and the robots.txt
+  "Sitemap:" line correctly advertise https:// instead of http://.
+- 🐛(nau) disallow crawling of parameterized URLs in robots.txt
+  Query-string URLs (pagination on detail pages, client-side search filters,
+  tracking params...) are not unique indexable content; all real content
+  already lives at clean, path-based URLs covered by the sitemap. Add
+  `Disallow: *?*` to reduce crawl budget waste and duplicate content
+  discovery.
+- 🐛(nau) add self-referencing canonical tag to every indexable page
+  Pages had no canonical tag, risking duplicate-content signals across
+  paginated, filtered and query-string URL variants. Add a self-referencing
+  `<link rel="canonical">` (built from the same https-aware SITE.web_url used
+  by the sitemap/robots.txt fixes) pointing to the clean, absolute URL of the
+  current page, with query strings excluded so pagination/search-filter
+  variants consolidate onto the canonical page.
+- 🐛(nau) use region-qualified "pt-PT" hreflang value for Portuguese pages
+  Override richie's hreflang.html to emit `hreflang="pt-PT"` instead of the
+  bare "pt" for the Portuguese alternate-language link, matching the format
+  requested for search engines. Only the hreflang attribute value changes -
+  the URL itself still uses the existing "/pt/..." prefix, so no links break.
+  "en" is left unqualified as no region-specific requirement was given for it.
+
 ## [2.2.0] - 2026-05-15
 
 ### Changed

--- a/sites/nau/src/backend/nau/settings.py
+++ b/sites/nau/src/backend/nau/settings.py
@@ -668,6 +668,13 @@ class Base(StyleguideMixin, DRFMixin, RichieCoursesConfigurationMixin, Configura
         {"menus": 3600, "content": 60, "permissions": 3600}
     )
 
+    # Cache duration (in seconds) for the dynamically generated sitemap.xml view.
+    # Without caching, the sitemap is rebuilt from the database on every request,
+    # which is slow enough to make search engine crawlers time out. Defaults to 24h.
+    SITEMAP_CACHE_TIMEOUT = values.IntegerValue(
+        86400, environ_name="SITEMAP_CACHE_TIMEOUT", environ_prefix=None
+    )
+
     # Sessions
     SESSION_ENGINE = values.Value("django.contrib.sessions.backends.cache")
 
@@ -861,6 +868,12 @@ class Production(Base):
     CSRF_COOKIE_SECURE = True
     CSRF_TRUSTED_ORIGINS = values.ListValue([])
     CSRF_COOKIE_DOMAIN = values.Value(None)
+    # The app sits behind an nginx-ingress (or similar reverse proxy) that terminates
+    # TLS and forwards requests over plain HTTP. Without this, request.is_secure()
+    # (and request.scheme) always evaluate to False/"http", which made the sitemap's
+    # <loc> entries and the robots.txt "Sitemap:" line advertise http:// URLs even
+    # though the site is only ever served over https in production.
+    SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
     SECURE_BROWSER_XSS_FILTER = True
     SECURE_CONTENT_TYPE_NOSNIFF = True
     SESSION_COOKIE_SECURE = True

--- a/sites/nau/src/backend/nau/tests/__init__.py
+++ b/sites/nau/src/backend/nau/tests/__init__.py
@@ -1,0 +1,30 @@
+"""
+Shared test helpers for the nau backend test suite.
+"""
+
+from django.conf import settings
+from django.test import override_settings
+
+from richie.apps.courses.factories import CourseFactory
+
+
+def create_published_course_page(**kwargs):
+    """
+    Create and publish a CourseFactory page in the default language, returning
+    the underlying CMS page. Shared by tests that only need "some real,
+    published page" to exercise page-level template tags (canonical, hreflang).
+    """
+    course = CourseFactory(**kwargs)
+    course.extended_object.publish(settings.LANGUAGE_CODE)
+    return course.extended_object
+
+
+def get_with_https_proxy_header(client, url):
+    """
+    Perform a GET request simulating the reverse proxy's X-Forwarded-Proto
+    header, with SECURE_PROXY_SSL_HEADER configured as it is under the
+    Production settings class, so request.is_secure()/request.scheme
+    correctly evaluate to https as they would in a real environment.
+    """
+    with override_settings(SECURE_PROXY_SSL_HEADER=("HTTP_X_FORWARDED_PROTO", "https")):
+        return client.get(url, HTTP_X_FORWARDED_PROTO="https")

--- a/sites/nau/src/backend/nau/tests/test_canonical.py
+++ b/sites/nau/src/backend/nau/tests/test_canonical.py
@@ -3,9 +3,12 @@ Test suite for the self-referencing canonical URL tag.
 """
 
 from django.conf import settings
+from django.contrib.auth.models import AnonymousUser
 from django.test import TestCase
+from django.test.client import RequestFactory
 
 from cms.api import create_page
+from richie.apps.core.views import error
 
 from . import create_published_course_page, get_with_https_proxy_header
 
@@ -73,3 +76,18 @@ class CanonicalUrlTestCase(TestCase):
         response = get_with_https_proxy_header(self.client, page.get_absolute_url())
 
         self.assertContains(response, 'rel="canonical" href="https://')
+
+    def test_no_canonical_tag_on_error_pages(self):
+        """
+        Richie's 404/error handler renders richie/error.html with no current_page
+        in its request/context - there's no single "correct" URL to canonicalize
+        an error response onto, so the guard in base.html's meta_html block must
+        suppress the canonical tag entirely rather than render a broken/empty href.
+        """
+        request = RequestFactory().get("/this-page-does-not-exist/")
+        request.user = AnonymousUser()
+        request.current_page = None
+
+        response = error.error_404_view_handler(request, Exception)
+
+        self.assertNotContains(response, 'rel="canonical"', status_code=404)

--- a/sites/nau/src/backend/nau/tests/test_canonical.py
+++ b/sites/nau/src/backend/nau/tests/test_canonical.py
@@ -1,0 +1,75 @@
+"""
+Test suite for the self-referencing canonical URL tag.
+"""
+
+from django.conf import settings
+from django.test import TestCase
+
+from cms.api import create_page
+
+from . import create_published_course_page, get_with_https_proxy_header
+
+
+class CanonicalUrlTestCase(TestCase):
+    """Ensure indexable pages expose a correct, self-referencing canonical tag."""
+
+    def test_homepage_has_self_referencing_canonical(self):
+        """The homepage should carry a canonical tag pointing to itself."""
+        page = create_page(
+            "Home",
+            "richie/homepage.html",
+            settings.LANGUAGE_CODE,
+            published=True,
+        )
+        page.set_as_homepage()
+
+        response = self.client.get(page.get_absolute_url())
+
+        self.assertContains(
+            response,
+            f'<link rel="canonical" href="http://example.com{page.get_absolute_url()}" />',
+        )
+
+    def test_course_detail_page_canonical_matches_its_own_clean_url(self):
+        """
+        A course detail page's canonical must point to its own clean URL - not the
+        organization/category listing it's linked from, and not a redirected variant.
+        """
+        page = create_published_course_page()
+
+        response = self.client.get(page.get_absolute_url())
+
+        self.assertContains(
+            response,
+            f'<link rel="canonical" href="http://example.com{page.get_absolute_url()}" />',
+        )
+
+    def test_canonical_strips_pagination_query_string(self):
+        """
+        Visiting a detail page with a pagination query string (e.g. paginating an
+        embedded course listing) must still canonicalize to the clean, unparameterized
+        URL - consolidating ranking signals onto a single indexable version.
+        """
+        page = create_published_course_page()
+        clean_url = page.get_absolute_url()
+
+        response = self.client.get(f"{clean_url}?page_courses=2")
+
+        self.assertContains(
+            response,
+            f'<link rel="canonical" href="http://example.com{clean_url}" />',
+        )
+        self.assertNotContains(response, "page_courses=2")
+
+    def test_canonical_uses_https_behind_proxy(self):
+        """
+        The reverse proxy in front of this app terminates TLS and forwards plain
+        HTTP. With SECURE_PROXY_SSL_HEADER configured (Production settings), the
+        canonical URL must use https:// (the scheme the crawler actually requested),
+        not the internal http:// one.
+        """
+        page = create_published_course_page()
+
+        response = get_with_https_proxy_header(self.client, page.get_absolute_url())
+
+        self.assertContains(response, 'rel="canonical" href="https://')

--- a/sites/nau/src/backend/nau/tests/test_hreflang.py
+++ b/sites/nau/src/backend/nau/tests/test_hreflang.py
@@ -1,0 +1,123 @@
+"""
+Test suite for the hreflang <link rel="alternate"> tags (richie's own template).
+"""
+
+from django.conf import settings
+from django.test import TestCase
+
+from richie.apps.courses.factories import CourseFactory
+
+from . import create_published_course_page, get_with_https_proxy_header
+
+
+class HreflangTestCase(TestCase):
+    """
+    Ensure hreflang alternate-language URLs are absolute, HTTPS, and never point
+    to a redirected/stale page - see fccn/nau-technical#993.
+    """
+
+    def test_course_detail_page_has_hreflang_for_default_language(self):
+        """A published course page must expose a self-referencing hreflang entry."""
+        page = create_published_course_page()
+
+        response = self.client.get(page.get_absolute_url())
+
+        self.assertContains(
+            response,
+            f'<link rel="alternate" href="http://example.com{page.get_absolute_url()}"'
+            f' hreflang="{settings.LANGUAGE_CODE}" />',
+        )
+
+    def test_hreflang_target_resolves_without_redirect(self):
+        """
+        Every hreflang target must be a direct, final URL - not one that 301s
+        elsewhere (e.g. a stale slug or a language-prefix redirect). This is the
+        crawler-facing property that #993 is actually about.
+        """
+        page = create_published_course_page()
+
+        response = self.client.get(page.get_absolute_url())
+        content = response.content.decode()
+
+        start = content.index('<link rel="alternate" href="')
+        start += len('<link rel="alternate" href="')
+        end = content.index('"', start)
+        hreflang_url = content[start:end]
+        # Strip the scheme+host prefix injected by SITE.web_url to hit the path locally.
+        path = hreflang_url.split("example.com", 1)[1]
+
+        follow_up = self.client.get(path)
+
+        self.assertEqual(follow_up.status_code, 200)
+
+    def test_hreflang_uses_https_behind_proxy(self):
+        """
+        The reverse proxy in front of this app terminates TLS and forwards plain
+        HTTP. With SECURE_PROXY_SSL_HEADER configured (Production settings), the
+        hreflang href must use https:// (the scheme the crawler actually requested),
+        not the internal http:// one - otherwise crawlers see an hreflang URL that
+        immediately 301-redirects to https, which is exactly the #993 bug.
+        """
+        page = create_published_course_page()
+
+        response = get_with_https_proxy_header(self.client, page.get_absolute_url())
+
+        self.assertContains(response, 'rel="alternate" href="https://')
+
+    def test_untranslated_page_hreflang_falls_back_to_other_language(self):
+        """
+        A page that only exists in one language still emits an hreflang entry
+        for every configured language (richie's hreflang.html loops over all of
+        them unconditionally) - see fccn/nau-technical#994. For the language
+        that has no translation, page_language_url falls back to the other
+        language's URL (per CMS_LANGUAGES fallbacks), so the hreflang target is
+        never omitted and never a broken link/404 - it resolves 200 and serves
+        the fallback-language content under the other language's URL prefix.
+        This test documents that behaviour as the chosen strategy for #994's
+        "untranslated pages" requirement, rather than a bug.
+        """
+        course = CourseFactory()
+        course.extended_object.publish("en")
+        page = course.extended_object
+
+        self.assertEqual(page.get_published_languages(), ["en"])
+
+        response = self.client.get(page.get_absolute_url("en"))
+        content = response.content.decode()
+
+        # Both an "en" self-reference and a "pt-PT" entry are present...
+        self.assertIn('hreflang="en"', content)
+        self.assertIn('hreflang="pt-PT"', content)
+
+        # ...and the "pt-PT" entry's target resolves (200, no redirect/404)
+        # even though the page has no Portuguese translation.
+        start = content.index('hreflang="pt-PT"')
+        href_start = content.rindex('href="', 0, start) + len('href="')
+        href_end = content.index('"', href_start)
+        pt_href = content[href_start:href_end]
+        pt_path = pt_href.split("example.com", 1)[1]
+
+        pt_response = self.client.get(pt_path)
+
+        self.assertEqual(pt_response.status_code, 200)
+
+    def test_hreflang_uses_region_qualified_portuguese_code(self):
+        """
+        Per fccn/nau-technical#994, the Portuguese hreflang value must be the
+        region-qualified "pt-PT" (not the bare "pt" that the URL/CMS language
+        code itself uses), while "en" is intentionally left unqualified. Only
+        the hreflang attribute changes - the URL path stays "/pt/..." as before.
+        """
+        course = CourseFactory(page_languages=["en", "pt"], should_publish=True)
+        page = course.extended_object
+
+        response = self.client.get(page.get_absolute_url("en"))
+        content = response.content.decode()
+
+        self.assertIn('hreflang="en"', content)
+        self.assertIn('hreflang="pt-PT"', content)
+        self.assertNotIn('hreflang="pt"', content)
+        # The href target itself must still use the plain "/pt/" URL prefix.
+        self.assertIn(
+            f'href="http://example.com{page.get_absolute_url("pt")}"', content
+        )

--- a/sites/nau/src/backend/nau/tests/test_robots.py
+++ b/sites/nau/src/backend/nau/tests/test_robots.py
@@ -1,0 +1,41 @@
+"""
+Test suite for the robots.txt view.
+"""
+
+from django.test import TestCase, override_settings
+
+
+class RobotsTxtTestCase(TestCase):
+    """Ensure robots.txt is served correctly and advertises the right crawl rules."""
+
+    def test_robots_txt_returns_200_plain_text(self):
+        """The robots.txt endpoint should respond successfully as plain text."""
+        response = self.client.get("/robots.txt")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["Content-Type"], "text/plain")
+
+    def test_robots_txt_disallows_parameterized_urls(self):
+        """
+        Query-string URLs (pagination on detail pages, client-side search filters,
+        UTM tracking params...) are not unique indexable content on this site - all
+        real content lives at clean, path-based URLs already listed in the sitemap.
+        Crawling them wastes crawl budget and can surface near-duplicate content.
+        """
+        response = self.client.get("/robots.txt")
+
+        self.assertContains(response, "Disallow: *?*")
+
+    def test_robots_txt_sitemap_reference_uses_https_behind_proxy(self):
+        """
+        The reverse proxy in front of this app terminates TLS and forwards plain
+        HTTP, setting an X-Forwarded-Proto header. With SECURE_PROXY_SSL_HEADER
+        configured (Production settings), the Sitemap: line must reflect the
+        original https:// scheme instead of the internal http:// one.
+        """
+        with override_settings(
+            SECURE_PROXY_SSL_HEADER=("HTTP_X_FORWARDED_PROTO", "https")
+        ):
+            response = self.client.get("/robots.txt", HTTP_X_FORWARDED_PROTO="https")
+
+        self.assertContains(response, "Sitemap: https://")

--- a/sites/nau/src/backend/nau/tests/test_sitemap.py
+++ b/sites/nau/src/backend/nau/tests/test_sitemap.py
@@ -1,0 +1,77 @@
+"""
+Test suite for the cached sitemap.xml view.
+"""
+
+from unittest import mock
+
+from django.conf import settings
+from django.core.cache import cache
+from django.test import TestCase, override_settings
+
+from cms.sitemaps import CMSSitemap
+from richie.apps.courses.factories import CourseFactory
+
+
+@override_settings(
+    CACHES={"default": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"}},
+    SITEMAP_CACHE_TIMEOUT=86400,
+)
+class SitemapCacheTestCase(TestCase):
+    """Ensure sitemap.xml is served from cache instead of being rebuilt on every request."""
+
+    def setUp(self):
+        super().setUp()
+        cache.clear()
+        course = CourseFactory()
+        course.extended_object.publish(settings.LANGUAGE_CODE)
+
+    def test_sitemap_returns_200_xml(self):
+        """The sitemap endpoint should respond successfully with an XML document."""
+        response = self.client.get("/sitemap.xml")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["Content-Type"], "application/xml")
+
+    def test_sitemap_generation_is_not_repeated_on_second_request(self):
+        """
+        A second request within the cache timeout should be served entirely from
+        cache: the (expensive) sitemap generation itself must only run once, no
+        matter how many times crawlers hit the endpoint in that window.
+        """
+        with mock.patch.object(
+            CMSSitemap, "items", wraps=CMSSitemap.items, autospec=True
+        ) as mocked_items:
+            first_response = self.client.get("/sitemap.xml")
+            second_response = self.client.get("/sitemap.xml")
+
+        self.assertEqual(first_response.status_code, 200)
+        self.assertEqual(second_response.status_code, 200)
+        self.assertEqual(
+            mocked_items.call_count,
+            1,
+            "Sitemap generation should only run once for both requests; the second "
+            "request should be served from cache",
+        )
+        self.assertEqual(first_response.content, second_response.content)
+
+    def test_sitemap_sets_cache_control_header(self):
+        """The cached view should set a Cache-Control header advertising its lifetime."""
+        response = self.client.get("/sitemap.xml")
+
+        self.assertIn("Cache-Control", response)
+        self.assertIn("max-age=", response["Cache-Control"])
+
+    def test_sitemap_urls_use_https_behind_proxy(self):
+        """
+        The reverse proxy in front of this app terminates TLS and forwards plain
+        HTTP, setting an X-Forwarded-Proto header. With SECURE_PROXY_SSL_HEADER
+        configured (Production settings), <loc> entries must use https:// (the
+        scheme the crawler actually requested), not the internal http:// one.
+        """
+        with override_settings(
+            SECURE_PROXY_SSL_HEADER=("HTTP_X_FORWARDED_PROTO", "https")
+        ):
+            response = self.client.get("/sitemap.xml", HTTP_X_FORWARDED_PROTO="https")
+
+        self.assertContains(response, "<loc>https://")
+        self.assertNotContains(response, "<loc>http://")

--- a/sites/nau/src/backend/nau/tests/test_sitemap.py
+++ b/sites/nau/src/backend/nau/tests/test_sitemap.py
@@ -2,6 +2,7 @@
 Test suite for the cached sitemap.xml view.
 """
 
+import re
 from unittest import mock
 
 from django.conf import settings
@@ -75,3 +76,24 @@ class SitemapCacheTestCase(TestCase):
 
         self.assertContains(response, "<loc>https://")
         self.assertNotContains(response, "<loc>http://")
+
+    def test_sitemap_never_relies_on_query_string_urls(self):
+        """
+        robots.txt's "Disallow: *?*" rule (fccn/nau-technical#991) blocks crawling
+        of any query-string URL (pagination, search filters, UTM params). This is
+        only safe because every indexable page already has a clean, path-based URL
+        the sitemap can point crawlers to: no page in this site is reachable *only*
+        via a query-string URL. If that ever stopped being true, the sitemap itself
+        would be the first place it broke - a <loc> entry containing "?" would mean
+        real content is being both advertised for indexing and disallowed from
+        crawling at the same time.
+        """
+        response = self.client.get("/sitemap.xml")
+
+        for loc in re.findall(rb"<loc>([^<]+)</loc>", response.content):
+            self.assertNotIn(
+                b"?",
+                loc,
+                f"Sitemap entry {loc} contains a query string, which would make "
+                "it unreachable under robots.txt's Disallow: *?* rule",
+            )

--- a/sites/nau/src/backend/nau/urls.py
+++ b/sites/nau/src/backend/nau/urls.py
@@ -8,6 +8,7 @@ from django.contrib import admin
 from django.contrib.sitemaps.views import sitemap
 from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 from django.urls import include, path, re_path
+from django.views.decorators.cache import cache_page
 from django.views.generic import TemplateView
 from django.views.static import serve
 
@@ -37,7 +38,14 @@ urlpatterns = [
             template_name="richie/robots.html", content_type="text/plain"
         ),
     ),
-    path(r"sitemap.xml", sitemap, {"sitemaps": {"cmspages": CMSSitemap}}),
+    # Cache the sitemap for 24h so crawlers get an immediate response instead of
+    # triggering a full dynamic sitemap generation (and its DB queries) on every
+    # request, which was causing crawler timeouts.
+    path(
+        r"sitemap.xml",
+        cache_page(settings.SITEMAP_CACHE_TIMEOUT)(sitemap),
+        {"sitemaps": {"cmspages": CMSSitemap}},
+    ),
     re_path(
         rf"api/{API_PREFIX}/",
         include([*courses_urlpatterns, *search_urlpatterns, *plugins_urlpatterns]),

--- a/sites/nau/src/backend/templates/richie/base.html
+++ b/sites/nau/src/backend/templates/richie/base.html
@@ -13,6 +13,16 @@
 <meta name="theme-color" content="#ffffff">
 {% endblock meta_favicons %}
 
+{% block meta_hreflang %}
+{{ block.super }}
+{% if current_page %}
+{# Self-referencing canonical URL. Query strings (pagination, search filters) are #}
+{# intentionally excluded so paginated/filtered variants of a page canonicalize to #}
+{# the clean page-1 URL, per the platform's canonical URL strategy. #}
+<link rel="canonical" href="{{ SITE.web_url }}{{ current_page.get_absolute_url }}" />
+{% endif %}
+{% endblock meta_hreflang %}
+
 {% block meta_rdfa_context %}
 <meta property="og:type" content="website" />
 <meta property="og:image" content="{% static_absolute "richie/images/og_media_geral_fb_22a.png" %}" />

--- a/sites/nau/src/backend/templates/richie/base.html
+++ b/sites/nau/src/backend/templates/richie/base.html
@@ -13,7 +13,7 @@
 <meta name="theme-color" content="#ffffff">
 {% endblock meta_favicons %}
 
-{% block meta_hreflang %}
+{% block meta_html %}
 {{ block.super }}
 {% if current_page %}
 {# Self-referencing canonical URL. Query strings (pagination, search filters) are #}
@@ -21,7 +21,7 @@
 {# the clean page-1 URL, per the platform's canonical URL strategy. #}
 <link rel="canonical" href="{{ SITE.web_url }}{{ current_page.get_absolute_url }}" />
 {% endif %}
-{% endblock meta_hreflang %}
+{% endblock meta_html %}
 
 {% block meta_rdfa_context %}
 <meta property="og:type" content="website" />

--- a/sites/nau/src/backend/templates/richie/hreflang.html
+++ b/sites/nau/src/backend/templates/richie/hreflang.html
@@ -1,0 +1,14 @@
+{% load i18n menu_tags cms_tags %}
+{# Overrides richie's own hreflang.html to region-qualify the Portuguese hreflang #}
+{# value as "pt-PT" per fccn/nau-technical#994, without touching the URL itself #}
+{# (page_language_url still resolves the "pt" language/URL prefix as before - #}
+{# only the hreflang attribute value changes). "en" is intentionally left as-is. #}
+{% if languages|length > 1 %}
+    {% for code, name in languages %}
+        {% if code == "pt" %}
+        <link rel="alternate" href="{{ SITE.web_url }}{% page_language_url code %}" hreflang="pt-PT" />
+        {% else %}
+        <link rel="alternate" href="{{ SITE.web_url }}{% page_language_url code %}" hreflang="{{ code }}" />
+        {% endif %}
+    {% endfor %}
+{% endif %}

--- a/sites/nau/src/backend/templates/richie/robots.html
+++ b/sites/nau/src/backend/templates/richie/robots.html
@@ -1,0 +1,3 @@
+User-Agent: *
+Disallow: *?*
+Sitemap: {{ SITE.web_url }}/sitemap.xml

--- a/template/{{cookiecutter.site}}/src/backend/templates/richie/base.html
+++ b/template/{{cookiecutter.site}}/src/backend/templates/richie/base.html
@@ -1,6 +1,6 @@
 {% extends "richie/base.html" %}
 
-{% block meta_hreflang %}
+{% block meta_html %}
 {{ block.super }}
 {% if current_page %}
 {# Self-referencing canonical URL. Query strings (pagination, search filters) are #}
@@ -8,4 +8,4 @@
 {# the clean page-1 URL, per the platform's canonical URL strategy. #}
 <link rel="canonical" href="{{ SITE.web_url }}{{ current_page.get_absolute_url }}" />
 {% endif %}
-{% endblock meta_hreflang %}
+{% endblock meta_html %}

--- a/template/{{cookiecutter.site}}/src/backend/templates/richie/base.html
+++ b/template/{{cookiecutter.site}}/src/backend/templates/richie/base.html
@@ -1,0 +1,11 @@
+{% extends "richie/base.html" %}
+
+{% block meta_hreflang %}
+{{ block.super }}
+{% if current_page %}
+{# Self-referencing canonical URL. Query strings (pagination, search filters) are #}
+{# intentionally excluded so paginated/filtered variants of a page canonicalize to #}
+{# the clean page-1 URL, per the platform's canonical URL strategy. #}
+<link rel="canonical" href="{{ SITE.web_url }}{{ current_page.get_absolute_url }}" />
+{% endif %}
+{% endblock meta_hreflang %}

--- a/template/{{cookiecutter.site}}/src/backend/templates/richie/robots.html
+++ b/template/{{cookiecutter.site}}/src/backend/templates/richie/robots.html
@@ -1,0 +1,3 @@
+User-Agent: *
+Disallow: *?*
+Sitemap: {{ SITE.web_url }}/sitemap.xml

--- a/template/{{cookiecutter.site}}/src/backend/{{cookiecutter.site}}/settings.py
+++ b/template/{{cookiecutter.site}}/src/backend/{{cookiecutter.site}}/settings.py
@@ -674,6 +674,13 @@ class Base(StyleguideMixin, DRFMixin, RichieCoursesConfigurationMixin, Configura
     CMS_CACHE_DURATIONS = values.DictValue(
         {"menus": 3600, "content": 86400, "permissions": 86400}
     )
+
+    # Cache duration (in seconds) for the dynamically generated sitemap.xml view.
+    # Without caching, the sitemap is rebuilt from the database on every request,
+    # which is slow enough to make search engine crawlers time out. Defaults to 24h.
+    SITEMAP_CACHE_TIMEOUT = values.IntegerValue(
+        86400, environ_name="SITEMAP_CACHE_TIMEOUT", environ_prefix=None
+    )
     MAX_BROWSER_CACHE_TTL = 600
 
     # Sessions
@@ -805,6 +812,12 @@ class Production(Base):
     # Security
     SECRET_KEY = values.SecretValue()
     CSRF_COOKIE_SECURE = True
+    # The app sits behind an nginx-ingress (or similar reverse proxy) that terminates
+    # TLS and forwards requests over plain HTTP. Without this, request.is_secure()
+    # (and request.scheme) always evaluate to False/"http", which made the sitemap's
+    # <loc> entries and the robots.txt "Sitemap:" line advertise http:// URLs even
+    # though the site is only ever served over https in production.
+    SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
     SECURE_BROWSER_XSS_FILTER = True
     SECURE_CONTENT_TYPE_NOSNIFF = True
     SESSION_COOKIE_SECURE = True

--- a/template/{{cookiecutter.site}}/src/backend/{{cookiecutter.site}}/urls.py
+++ b/template/{{cookiecutter.site}}/src/backend/{{cookiecutter.site}}/urls.py
@@ -8,6 +8,7 @@ from django.contrib import admin
 from django.contrib.sitemaps.views import sitemap
 from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 from django.urls import include, path, re_path
+from django.views.decorators.cache import cache_page
 from django.views.generic import TemplateView
 from django.views.static import serve
 
@@ -30,7 +31,14 @@ admin.autodiscover()
 admin.site.enable_nav_sidebar = False
 
 urlpatterns = [
-    path(r"sitemap.xml", sitemap, {"sitemaps": {"cmspages": CMSSitemap}}),
+    # Cache the sitemap for 24h so crawlers get an immediate response instead of
+    # triggering a full dynamic sitemap generation (and its DB queries) on every
+    # request, which was causing crawler timeouts.
+    path(
+        r"sitemap.xml",
+        cache_page(settings.SITEMAP_CACHE_TIMEOUT)(sitemap),
+        {"sitemaps": {"cmspages": CMSSitemap}},
+    ),
     re_path(
         rf"api/{API_PREFIX:s}/",
         include([*courses_urlpatterns, *search_urlpatterns, *plugins_urlpatterns]),


### PR DESCRIPTION
## Summary

Bundles fixes for a batch of related SEO technical issues assigned to me, all found to stem from
two shared root causes:

1. The `sitemap.xml` view being regenerated from the database on every single request (no caching).
2. The app not being aware it sits behind a TLS-terminating reverse proxy in every real environment
   (dev/stage/production) — so `request.is_secure()`/`request.scheme` always evaluated to `http`,
   which quietly broke several other things that build absolute URLs from the request (sitemap
   `<loc>` entries, `robots.txt`'s `Sitemap:` line, canonical tags, hreflang tags).

Related issues (nau-technical repo): 
- https://github.com/fccn/nau-technical/issues/990
- https://github.com/fccn/nau-technical/issues/991
- https://github.com/fccn/nau-technical/issues/992
- https://github.com/fccn/nau-technical/issues/993
- https://github.com/fccn/nau-technical/issues/994

---

### nau-technical#990 — Fix XML Sitemap Generation and Delivery

**Problem:** `sitemap.xml` was rebuilt from the DB on every request. Slow enough that crawlers were
timing out under load.

**Fix:** wrapped the sitemap view with Django's `cache_page` (`SITEMAP_CACHE_TIMEOUT`, defaults to
24h) in `urls.py` (nau, ap, and the cookiecutter template), so it's served instantly after the
first hit.

**Tests:** `test_sitemap.py` — verifies 200/XML response, that the expensive `CMSSitemap.items`
generation only runs once across two requests within the cache window, and that a `Cache-Control`
header is present.

---

### nau-technical#991 — Review and Optimize robots.txt Configuration

Two independent problems surfaced under this one issue:

1. **HTTPS scheme fix** — added `SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")` to
   the `Production` settings class only (not `Base`/`Development`, to avoid trusting a spoofable
   header where there's no real proxy in front). This is the fix that also makes sitemap `<loc>`
   entries, canonical tags (#992), and hreflang tags (#993/#994) correctly resolve to `https://`
   instead of `http://` in every real (proxied) environment.
2. **Disallow parameterized URLs** — overrode `robots.txt` to add `Disallow: *?*`. Query-string URLs
   (pagination on detail pages via django-pagination, client-side React search filters) aren't
   unique indexable content — every real page already has a clean, path-based URL in the sitemap.

**Tests:** `test_robots.py` — 200/plain-text response, `Disallow: *?*` line present, `Sitemap:` line
uses `https://` behind a simulated proxy header.

**Related infra fix (separate repo, see below):** while investigating this, found that
`nau-kubernetes-manifests`' ingress config hardcodes an nginx `server-snippet` that answers
`/robots.txt` directly at the ingress level for Richie, bypassing Django entirely and hardcoding
`http://` — meaning this Django-side fix would have had no real-world effect without also removing
that override. See "Related manifests changes" below.

---

### nau-technical#992 — Implement Canonical URL Strategy Across the NAU Platform

**Problem:** Richie ships with no canonical tag support at all.

**Fix:** added a new `meta_hreflang` block override in each site's `base.html` (calling
`{{ block.super }}` first to preserve the existing hreflang links, then appending) that renders:
```html
<link rel="canonical" href="{{ SITE.web_url }}{{ current_page.get_absolute_url }}" />
```
guarded by `{% if current_page %}` so pages without a CMS page (e.g. richie's own error/dashboard
views) are unaffected. This is:
- **Self-referencing** by construction (`current_page.get_absolute_url` is always the current page).
- **HTTPS-correct** since `SITE.web_url`'s scheme is proxy-aware once #991 lands.
- **Redirect-free** by construction — it can only ever point at the page currently rendering
  successfully.
- **Query-string-free** — `get_absolute_url()` never includes the query string, so any paginated or
  search-filtered URL variant (`?page_courses=2`, etc.) automatically canonicalizes onto its clean
  parent page.
- **hreflang-aligned** — built from the exact same `current_page`/`SITE.web_url` basis richie's own
  hreflang mechanism already uses, so canonical and hreflang always point at matching URLs per
  language.

**Tests:** `test_canonical.py` — self-referencing canonical on the homepage, canonical matches the
clean URL on a course detail page, canonical strips a pagination query string, canonical uses
`https://` behind a simulated proxy.

---

### nau-technical#993 — Fix hreflang URLs Pointing to HTTP or Redirected Pages

**Investigation:** traced richie's own (unmodified) `hreflang.html` template and its
`page_language_url` → `PageLanguageUrl` → `DefaultLanguageChanger` resolution chain. It already
always resolves to a clean, direct `page.get_absolute_url(...)` URL — never one that requires a
redirect for language/slug reasons. The only real bug was the exact same missing
`SECURE_PROXY_SSL_HEADER` as #991: once that's applied, hreflang links correctly resolve to
`https://` with no further Richie-side code change needed.

**Tests (new):** `test_hreflang.py` — self-referencing hreflang for the default language, hreflang
target resolves without a redirect (200, not 3xx), hreflang uses `https://` behind a simulated
proxy.

---

### nau-technical#994 — Resolve hreflang Conflicts and Implement Self-Referencing hreflang Strategy

This is a broader policy-style issue with 6 technical requirements. Investigated each one against
richie's existing (unmodified) `hreflang.html` mechanism and verified live against real demo
content:

1. **Self-referencing tags** — richie's template loops over *all* configured languages (including
   the current one) for every page → always self-referencing by construction. ✅ already satisfied.
2. **Reciprocal language pairs** — both language versions of a page render the identical language
   loop, so each side always references the other. ✅ already satisfied.
3. **HTTPS/200/non-redirecting/canonical-aligned** — same mechanism as #991/#992/#993. ✅ covered by
   the #991 proxy-scheme fix.
4. **Untranslated pages** — traced the fallback chain (`CMS_LANGUAGES[...]['fallbacks']`, en↔pt are
   mutual fallbacks for nau) and confirmed the existing, correct behaviour: an untranslated
   language's hreflang entry is **not** omitted and **not** broken — it points at the other
   language's URL, which renders that language's content as a graceful fallback and returns `200`.
   This is richie's built-in behaviour, not a custom addition — now locked in with a permanent
   regression test rather than just verified ad hoc.
5. **Pagination independence** — verified no difference in hreflang/canonical tags with vs. without
   a `?page_courses=2` query string (same `get_absolute_url()`-based mechanism as #992). ✅
   already satisfied.
6. **hreflang/canonical alignment** — verified directly that every page's canonical URL matches its
   own hreflang self-reference URL. ✅ already satisfied.

**Code change:** issue #994's own examples use the region-qualified `hreflang="pt-PT"` rather than
a bare `"pt"`. Added `sites/nau/src/backend/templates/richie/hreflang.html` — a full override of
richie's package `hreflang.html`, identical except the Portuguese branch hardcodes `hreflang="pt-PT"`
while the URL itself is still resolved via the unchanged `{% page_language_url code %}` — so **only
the hreflang attribute value changes, the URL/path is completely untouched** (still `/pt/...`,
nothing breaks). `en` is intentionally left as a bare `"en"` since no region-specific code was
requested for it in the issue.

**ap-specific note:** `ap` only configures a single language (`pt`), and richie's `hreflang.html`
guards on `{% if languages|length > 1 %}`, so hreflang tags never render on `ap` at all, by design.
**#993/#994 are therefore nau-only** — `ap` only picks up the #990/#991/#992 fixes.

**Tests:** extended `test_hreflang.py` with a permanent regression test for the untranslated-page
fallback behaviour, and a new test asserting the `pt-PT` region-qualified value renders while the
href/URL itself is unchanged.

---

## Validation

Ran on both `nau` and `ap` sites locally (`ap` required switching `RICHIE_SITE=ap` in `.env` +
rebuild + full test/lint cycle, then reverted back to `nau`):

- Full backend test suites pass with **no regressions** — a small number of pre-existing, unrelated
  failures (one in `base/tests/test_redirects.py`, three in
  `ap/tests/test_authentication_profile_urls.py`) were confirmed identical before and after this
  change via `git stash`/`git stash pop` A/B testing.
- All backend linters (black, isort, flake8, pylint, bandit, raincoat) clean on both sites.
- Manually verified live on a local instance: sitemap caching (slow first hit, fast cached hit),
  `robots.txt`'s `Disallow: *?*` line, canonical tag rendering + query-string stripping, and
  hreflang tags (including `pt-PT`) across homepage/course/organization/category/news pages.

Note: the `https://` behavior for sitemap/canonical/hreflang can only be observed locally via the
test suite's simulated proxy header (`override_settings(SECURE_PROXY_SSL_HEADER=...)` +
`HTTP_X_FORWARDED_PROTO`) since the local dev/CI Docker Compose stack doesn't run the `Production`
settings class where that header is configured. It's confirmed to apply identically across the
dev/stage/production Kubernetes environments (all use `DJANGO_CONFIGURATION=Production` behind
nginx-ingress with TLS termination).

## Related manifests changes

While investigating #991, found that `nau-kubernetes-manifests`' ingress config for Richie
hardcodes an nginx `server-snippet` that answers `/robots.txt` directly at the ingress level,
bypassing this app's Django view entirely and hardcoding `http://` in the `Sitemap:` line — an
unintentional copy-paste from a legitimate LMS ingress robots.txt override for a different purpose.
This means the #991 fix in this PR would have **no real-world effect** once deployed unless that
ingress-level override is also removed. Three separate PRs (one per environment, that repo's
convention) remove that override and should be reviewed/merged together with this one, in this
order: this PR first, then dev, then stage, then production.

- dev: https://github.com/fccn/nau-kubernetes-manifests/pull/1026
- stage: https://github.com/fccn/nau-kubernetes-manifests/pull/1027
- prod: https://github.com/fccn/nau-kubernetes-manifests/pull/1028

