### PR TITLE
📌(nau,ap) pin Django and djangocms-link versions

### DIFF
--- a/sites/ap/CHANGELOG.md
+++ b/sites/ap/CHANGELOG.md
@@ -8,6 +8,16 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- 📌(ap) pin Django and djangocms-link versions
+  richie leaves Django and djangocms-link as unpinned transitive
+  dependencies, so a fresh image build can silently resolve a newer
+  djangocms-link with a breaking DB migration (5.2.0 renamed the
+  Link.target column to link_target). Pin both to the versions
+  currently deployed and already migrated (Django 4.2.30,
+  djangocms-link 5.1.1) to prevent future drift on rebuild.
+
 ## [1.5.1] - 2026-08-20
 
 ### Fixed

--- a/sites/ap/requirements/base.txt
+++ b/sites/ap/requirements/base.txt
@@ -4,7 +4,9 @@ richie==3.4.0
 # Pin transitive deps of richie that are otherwise left unpinned, so a
 # fresh image build doesn't silently drift to a newer version with a
 # breaking DB migration (djangocms-link 5.2.0 renamed a DB column and
-# caused a dev outage when nau:2.2.1/ap:1.5.1 were rebuilt).
+# caused a dev outage when nau:2.2.1/ap:1.5.1 were rebuilt). These pins
+# are tied to richie==3.4.0 above: revisit them whenever richie is
+# upgraded, rather than assuming they can stay untouched forever.
 Django==4.2.30
 djangocms-link==5.1.1
 unidecode==1.3.6 # required by django-check-seo

--- a/sites/ap/requirements/base.txt
+++ b/sites/ap/requirements/base.txt
@@ -1,6 +1,12 @@
 boto3==1.43.8
 django-check-seo==0.6.4
 richie==3.4.0
+# Pin transitive deps of richie that are otherwise left unpinned, so a
+# fresh image build doesn't silently drift to a newer version with a
+# breaking DB migration (djangocms-link 5.2.0 renamed a DB column and
+# caused a dev outage when nau:2.2.1/ap:1.5.1 were rebuilt).
+Django==4.2.30
+djangocms-link==5.1.1
 unidecode==1.3.6 # required by django-check-seo
 django-configurations==2.5.1
 # Superior versions of django-storages are not compatible with

--- a/sites/nau/CHANGELOG.md
+++ b/sites/nau/CHANGELOG.md
@@ -8,6 +8,16 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- 📌(nau) pin Django and djangocms-link versions
+  richie leaves Django and djangocms-link as unpinned transitive
+  dependencies, so a fresh image build can silently resolve a newer
+  djangocms-link with a breaking DB migration (5.2.0 renamed the
+  Link.target column to link_target). Pin both to the versions
+  currently deployed and already migrated (Django 4.2.30,
+  djangocms-link 5.1.1) to prevent future drift on rebuild.
+
 ## [2.2.1] - 2026-08-20
 
 ### Fixed

--- a/sites/nau/requirements/base.txt
+++ b/sites/nau/requirements/base.txt
@@ -4,7 +4,9 @@ richie==3.4.0
 # Pin transitive deps of richie that are otherwise left unpinned, so a
 # fresh image build doesn't silently drift to a newer version with a
 # breaking DB migration (djangocms-link 5.2.0 renamed a DB column and
-# caused a dev outage when nau:2.2.1/ap:1.5.1 were rebuilt).
+# caused a dev outage when nau:2.2.1/ap:1.5.1 were rebuilt). These pins
+# are tied to richie==3.4.0 above: revisit them whenever richie is
+# upgraded, rather than assuming they can stay untouched forever.
 Django==4.2.30
 djangocms-link==5.1.1
 unidecode==1.3.6 # required by django-check-seo

--- a/sites/nau/requirements/base.txt
+++ b/sites/nau/requirements/base.txt
@@ -1,6 +1,12 @@
 boto3==1.43.8
 django-check-seo==0.6.4
 richie==3.4.0
+# Pin transitive deps of richie that are otherwise left unpinned, so a
+# fresh image build doesn't silently drift to a newer version with a
+# breaking DB migration (djangocms-link 5.2.0 renamed a DB column and
+# caused a dev outage when nau:2.2.1/ap:1.5.1 were rebuilt).
+Django==4.2.30
+djangocms-link==5.1.1
 unidecode==1.3.6 # required by django-check-seo
 django-configurations==2.5.1
 # Superior versions of django-storages are not compatible with


### PR DESCRIPTION
## What

Pins `Django==4.2.30` and `djangocms-link==5.1.1` explicitly in `sites/nau/requirements/base.txt` and `sites/ap/requirements/base.txt`.

## Why

Both packages are currently left as **unpinned transitive dependencies** of `richie==3.4.0`. Because they aren't pinned, each fresh image build resolves whatever the latest compatible release is *at build time*.

This caused a dev outage after the `nau:2.2.1`/`ap:1.5.1` images (built for the SEO fixes in #377/#378) picked up `djangocms-link 5.2.0` instead of `5.1.1` — a version that ships `RenameField(target -> link_target)` on the `Link` model. That migration wasn't applied to the dev DB, so every request 500'd with `Unknown column 'djangocms_link_link.link_target'`.

The dependency drift is unrelated to the SEO PR's own code changes (verified zero diff in `requirements/` between the `nau-2.2.0` and `nau-2.2.1` git tags) — `djangocms-link` isn't listed anywhere in either site's requirements, it just comes in transitively via `richie`.

Pinning to the versions currently deployed (and already migrated) in stage/prod prevents this class of surprise drift on future rebuilds.

## Scope

This is a hygiene fix only — no release/version bump included here. A separate release (`bin/release nau|ap --commit` + tag) will be triggered once this is merged, to actually produce new images with these pins applied.