### PR TITLE
🔖(nau,ap) bump to versions 2.2.2 and 1.5.2

### DIFF
--- a/sites/ap/CHANGELOG.md
+++ b/sites/ap/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.5.2] - 2026-08-21
+
 ### Fixed
 
 - 📌(ap) pin Django and djangocms-link versions

--- a/sites/ap/src/backend/ap/__init__.py
+++ b/sites/ap/src/backend/ap/__init__.py
@@ -1,2 +1,2 @@
 # pylint: disable=missing-module-docstring
-__version__ = "1.5.1"
+__version__ = "1.5.2"

--- a/sites/ap/src/frontend/package.json
+++ b/sites/ap/src/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ap",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Richie AP NAU site on https://ap.nau.edu.pt/",
   "scripts": {
     "build-sass": "sass scss/_main.scss ../backend/base/static/richie/css/main.css --load-path=node_modules",

--- a/sites/nau/CHANGELOG.md
+++ b/sites/nau/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [2.2.2] - 2026-08-21
+
 ### Fixed
 
 - 📌(nau) pin Django and djangocms-link versions

--- a/sites/nau/src/backend/nau/__init__.py
+++ b/sites/nau/src/backend/nau/__init__.py
@@ -1,2 +1,2 @@
 # pylint: disable=missing-module-docstring
-__version__ = "2.2.1"
+__version__ = "2.2.2"

--- a/sites/nau/src/frontend/package.json
+++ b/sites/nau/src/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nau",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "Richie NAU site on https://www.nau.edu.pt",
   "scripts": {
     "build-sass": "sass scss/_main.scss ../backend/base/static/richie/css/main.css --load-path=node_modules",


### PR DESCRIPTION
Release PR cutting new patch versions for the dependency pin fix merged in #379 (nau-technical #990).

- nau: 2.2.1 → 2.2.2
- ap: 1.5.1 → 1.5.2

Both are patch/revision bumps since #379 only contained `Fixed` changelog entries. This PR triggers `hub-nau`/`hub-ap` to build and push the new Docker images (`nauedu/nau:2.2.2`, `nauedu/ap:1.5.2`), which pin Django/djangocms-link versions and are needed to fix the dev outage caused by unpinned transitive dependency drift (see fccn/nau-kubernetes-manifests#1029/#1027/#1028).

Generated with `bin/release nau ap --commit`, no manual changes.